### PR TITLE
Update container image to Fedora 32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Upgrade to a more recent fedora version
-FROM fedora:29
+FROM fedora:32
 
 # The caller should build a Freshmaker RPM package and then pass it in this arg.
 ARG cacert_url=undefined
@@ -22,13 +22,6 @@ COPY yum-packages.txt /tmp/yum-packages.txt
 
 RUN \
     dnf -y install $(cat /tmp/yum-packages.txt) python3-rhmsg && \
-    dnf -y downgrade \
-        https://kojipkgs.fedoraproject.org//packages/qpid-proton/0.26.0/1.fc29/x86_64/qpid-proton-c-0.26.0-1.fc29.x86_64.rpm \
-        https://kojipkgs.fedoraproject.org//packages/qpid-proton/0.26.0/1.fc29/x86_64/python3-qpid-proton-0.26.0-1.fc29.x86_64.rpm \
-        && \
-    dnf -y upgrade https://kojipkgs.fedoraproject.org/packages/kobo/0.10.0/1.fc31/noarch/python3-kobo-0.10.0-1.fc31.noarch.rpm \
-        https://kojipkgs.fedoraproject.org/packages/kobo/0.10.0/1.fc31/noarch/python3-kobo-rpmlib-0.10.0-1.fc31.noarch.rpm \
-        && \
     dnf clean all
 
 WORKDIR /src

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -24,6 +24,7 @@ python3-munch
 python3-odcs-client
 python3-openidc-client
 python3-pdc-client
+python3-pip
 python3-prometheus_client
 python3-psutil
 python3-psycopg2
@@ -37,4 +38,3 @@ python3-sqlalchemy
 python3-systemd
 python3-tabulate
 systemd
-


### PR DESCRIPTION
1. Tested latest qpid-proton doesn't have the memory leak issue, so we don't need the old version of qpid-proton packages.
2. Tested with some messages locally, handlers can run without issue.