### PR TITLE
 Modify script to load a cassette

### DIFF
--- a/dev_scripts/README.md
+++ b/dev_scripts/README.md
@@ -24,3 +24,21 @@ the errata_id and it submits a build in dry_run mode.
 
 By default, the script is executed on prod. To execute the script on dev the parameter `--dev` 
 should be added.
+
+
+### find_images_to_rebuild
+
+This script can be used to find images to rebuild by an Errata ID Event. The argument 
+`--container-image` can be used to provide the NVRs of images to rebuild. If not specified, all 
+images will be rebuilt that are affected by the advisory. The `--cassette-path` argument can be set 
+to the path of a vcrpy cassette downloaded from a deployed Freshmaker instance. This will use the 
+recorded Lightblue queries instead of querying Lightblue directly.
+ 
+ Example usage:
+ 
+ ```bash
+python3 find_images_to_rebuild.py 53137
+  ```
+ ```bash
+python3 find_images_to_rebuild.py 53137 --cassette-path ~/vcr_test/fixtures/cassettes/1.yml
+ ```

--- a/dev_scripts/find_images_to_rebuild.py
+++ b/dev_scripts/find_images_to_rebuild.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import os
 import sys
+import argparse
 from pprint import pprint
 from unittest.mock import patch
 from logging.config import dictConfig
@@ -15,12 +16,19 @@ os.environ["FRESHMAKER_DEVELOPER_ENV"] = "1"
 os.environ["FRESHMAKER_CONFIG_FILE"] = os.path.join(sys.path[0], "config.py")
 os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-bundle.crt"
 
-from freshmaker import db, app
+from freshmaker import db, app, conf
 from freshmaker.errata import Errata, ErrataAdvisory
 from freshmaker.events import (
     ErrataAdvisoryStateChangedEvent, ManualRebuildWithAdvisoryEvent)
 from freshmaker.handlers.koji import RebuildImagesOnRPMAdvisoryChange
 
+parser = argparse.ArgumentParser()
+parser.add_argument('errata_event_id', type=int, help='Errata event ID')
+parser.add_argument('--cassette-path', default=False, dest='cassette',
+                    help='Set a path to a cassette')
+parser.add_argument('--container-image', nargs='+', default=False, dest='container_img',
+                    help='Container images id')
+args = parser.parse_args()
 fedmsg_config = fedmsg.config.load_config()
 dictConfig(fedmsg_config.get('logging', {'version': 1}))
 
@@ -28,8 +36,6 @@ if len(sys.argv) < 2:
     print("Queries Lightblue to find out all the images Freshmaker rebuilds.")
     print("Usage: ./lightblue.py ERRATA_ID [[CONTAINER_IMAGE], ...]")
     sys.exit(1)
-
-container_images = sys.argv[2:]
 
 app_context = app.app_context()
 app_context.__enter__()
@@ -40,15 +46,33 @@ db.session.commit()
 
 errata = Errata()
 kwargs = {}
-if container_images:
+
+if args.container_img:
     EventClass = ManualRebuildWithAdvisoryEvent
-    kwargs['container_images'] = container_images
+    kwargs['container_images'] = args.container_img
 else:
     EventClass = ErrataAdvisoryStateChangedEvent
+
+event_id = None
+if args.cassette:
+    cassette_name = os.path.splitext(os.path.basename(args.cassette))[0]
+    extension = os.path.splitext(os.path.basename(args.cassette))[1]
+    try:
+        event_id = int(cassette_name)
+        if extension != ".yml":
+            raise ValueError
+    except ValueError:
+        print("The input cassette must be named in the format of <event ID>.yml")
+        sys.exit(1)
+
+    conf.vcrpy_path = os.path.dirname(args.cassette)
+    conf.vcrpy_mode = 'none'
+
 event = EventClass(
     "fake_message", ErrataAdvisory.from_advisory_id(errata, sys.argv[1]),
-    dry_run=True, **kwargs)
+    dry_run=True, freshmaker_event_id=event_id, **kwargs)
 
 handler = RebuildImagesOnRPMAdvisoryChange()
+
 with patch("freshmaker.consumer.get_global_consumer"):
     handler.handle(event)


### PR DESCRIPTION
Modify the "find_images_to_rebuild.py" script to be able to use a
cassette downloaded from the Freshmaker production instance rather
than querying Lightblue directly.