### PR TITLE
Add version requirements for Flask to deal with redirections problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pdc-client
 pyOpenSSL
 python-fedora
 sqlalchemy
-Flask
+Flask>=1.0.3
 Flask-Migrate
 Flask-SQLAlchemy
 Flask-Login

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -634,6 +634,13 @@ class TestViews(helpers.ModelsTestCase):
         self.assertEqual(data['depends_on_events'], [event1.id])
         self.assertEqual(data['depending_events'], [])
 
+    def test_trailing_slash(self):
+        urls = ('/api/2/builds', '/api/2/builds/',
+                '/api/2/events', '/api/2/events/')
+        for url in urls:
+            response = self.client.get(url, follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+
 
 class TestViewsMultipleFilterValues(helpers.ModelsTestCase):
     def setUp(self):


### PR DESCRIPTION
Flask v1.0.3 fixed this bug https://github.com/pallets/flask/issues/2984.
So we just need to specify required version of Flask to be installed +
some tests.

Resolves: FACTORY-5859
Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>