### PR TITLE
Update parent image when parent image's version changes

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -1394,8 +1394,9 @@ class LightBlue(object):
                     latest_image = nvr_to_image[latest_released_nvr]
                     if "parent" not in latest_image or not latest_image["parent"]:
                         continue
-                    latest_parent_name = koji.parse_NVR(
-                        latest_image["parent"].nvr)["name"]
+                    latest_parent_nvr_dict = koji.parse_NVR(latest_image["parent"].nvr)
+                    latest_parent_name = latest_parent_nvr_dict["name"]
+                    latest_parent_version = latest_parent_nvr_dict["version"]
 
                     # Go through the older images and in case the parent image differs,
                     # update its parents according to latest image parents.
@@ -1403,8 +1404,10 @@ class LightBlue(object):
                         image = nvr_to_image[nvr]
                         if "parent" not in image or not image["parent"]:
                             continue
-                        parent_name = koji.parse_NVR(image["parent"].nvr)["name"]
-                        if parent_name != latest_parent_name:
+                        parent_nvr_dict = koji.parse_NVR(image["parent"].nvr)
+                        parent_name = parent_nvr_dict["name"]
+                        parent_version = parent_nvr_dict["version"]
+                        if (parent_name, parent_version) != (latest_parent_name, latest_parent_version):
                             for image_id, parent_id in nvr_to_coordinates[nvr]:
                                 latest_image_id, latest_parent_id = nvr_to_coordinates[latest_released_nvr][0]
                                 to_rebuild[image_id][parent_id:] = to_rebuild[latest_image_id][latest_parent_id:]


### PR DESCRIPTION
The comment in _deduplicate_images_to_rebuild says:

    # 1) "handle_parent_change" - During this phase, we find out if update
    #    to latest image changes also the parent images.
    #    For example, foo-1-1 can be built against x-1-1, but foo-1-2 can
    #    be built against y-1-1. If we simply replace "foo-1-1" by "foo-1-2"
    #    while keeping the original parent image, the "foo-1-2" will be built
    #    against x-1-1 instead of y-1-1. This would be wrong.

the current implementation is updating the parent when parent is
changed from x-1-1 to y-1-1, where the name is changed, so why not
also update parent when only version changes?

With this change, if we have a case of:

    - foo-1-1 was built against x-1-1
    - foo-1-2 was built against x-2-1

then in additional to replace "foo-1-1" by "foo-1-2", we update parent
image to "x-2-1" as well.