### PR TITLE
[WIP]Remove some old references of pagure and fedoraproject

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -45,10 +45,10 @@ class BaseConfiguration(object):
     MESSAGING_TOPIC_PREFIX = ['org.fedoraproject.prod']
 
     # Base URL of git repository with source artifacts.
-    GIT_BASE_URL = "git://pkgs.fedoraproject.org"
+    GIT_BASE_URL = "git://pkgs.devel.redhat.com"
 
     # SSH base URL of git repository
-    GIT_SSH_BASE_URL = "ssh://%s@pkgs.fedoraproject.org/"
+    GIT_SSH_BASE_URL = "ssh://%s@pkgs.devel.redhat.com/"
 
     # GIT user for cloning and pushing repo
     GIT_USER = ""
@@ -165,12 +165,11 @@ class BaseConfiguration(object):
     # The base to query for users in LDAP. For example, ou=users,dc=example,dc=com.
     AUTH_LDAP_USER_BASE = ''
 
+    # OIDC provider
     AUTH_OPENIDC_USERINFO_URI = 'https://id.fedoraproject.org/openidc/UserInfo'
 
     # OIDC base namespace
-    # See also section pagure.io/odcs in
-    # https://fedoraproject.org/wiki/Infrastructure/Authentication
-    OIDC_BASE_NAMESPACE = 'https://pagure.io/freshmaker/'
+    OIDC_BASE_NAMESPACE = ''
 
     # Scope requested from Fedora Infra for permission of submitting request to
     # run a new compose.

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -184,11 +184,11 @@ class Config(object):
             'desc': 'Polling interval, in seconds.'},
         'git_base_url': {
             'type': str,
-            'default': "git://pkgs.fedoraproject.org",
+            'default': "git://pkgs.devel.redhat.com",
             'desc': 'Dist-git base URL.'},
         'git_ssh_base_url': {
             'type': str,
-            'default': "ssh://%s@pkgs.fedoraproject.org/",
+            'default': "ssh://%s@pkgs.devel.redhat.com/",
             'desc': 'Dist-git ssh base URL.'},
         'git_user': {
             'type': str,
@@ -196,7 +196,7 @@ class Config(object):
             'desc': 'User for git operations.'},
         'git_author': {
             'type': str,
-            'default': 'Freshmaker <freshmaker-owner@fedoraproject.org>',
+            'default': 'Freshmaker <freshmaker-owner@github.com>',
             'desc': 'Author for git commit.'},
         'koji_profile': {
             'type': str,
@@ -353,7 +353,7 @@ class Config(object):
                     'The "$tid" is replaced by thread ID'},
         'oidc_base_namespace': {
             'type': str,
-            'default': 'https://pagure.io/freshmaker/',
+            'default': '',
             'desc': 'Base namespace of OIDC scopes.'},
         'dogpile_cache_backend': {
             'type': str,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='freshmaker',
       author='The Factory 2.0 Team',
       # TODO: Not sure which name would be used for mail alias,
       # but let's set this proactively to the new name.
-      author_email='freshmaker-owner@fedoraproject.org',
+      author_email='freshmaker-owner@github.com',
       url='https://github.com/redhat-exd-rebuilds/freshmaker',
       license='MIT',
       packages=find_packages(exclude=['tests', 'tests.*']),

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -196,7 +196,7 @@ class TestGetRepoURLs(helpers.ModelsTestCase):
         handler = MyHandler()
         handler.build_image_artifact_build(self.build_1)
         build_container.assert_called_once_with(
-            'git://pkgs.fedoraproject.org/repo#hash', 'branch', 'target',
+            'git://pkgs.devel.redhat.com/repo#hash', 'branch', 'target',
             arch_override='x86_64', compose_ids=[5, 6, 7, 8], isolated=True,
             koji_parent_build=None, release='2.1234567', repo_urls=None)
 
@@ -213,7 +213,7 @@ class TestGetRepoURLs(helpers.ModelsTestCase):
         handler = MyHandler()
         handler.build_image_artifact_build(self.build_1)
         build_container.assert_called_once_with(
-            'git://pkgs.fedoraproject.org/repo#hash', 'branch', 'target',
+            'git://pkgs.devel.redhat.com/repo#hash', 'branch', 'target',
             arch_override='x86_64', compose_ids=[5, 6, 7, 8, 7300, 7301],
             isolated=True, koji_parent_build=None, release='2.1234567', repo_urls=None)
 
@@ -227,7 +227,7 @@ class TestGetRepoURLs(helpers.ModelsTestCase):
 
         repo_urls = ['http://localhost/x.repo']
         build_container.assert_called_once_with(
-            'git://pkgs.fedoraproject.org/repo#hash', 'branch', 'target',
+            'git://pkgs.devel.redhat.com/repo#hash', 'branch', 'target',
             arch_override='x86_64', compose_ids=[5, 6, 7, 8], isolated=True,
             koji_parent_build=None, release='2.1234567', repo_urls=repo_urls)
 


### PR DESCRIPTION
Some fedora references are left because it could be useful in future for OIDC authentication.

RESOLVE: CLOUDWF-2666

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>