### PR TITLE
Adding the findutils install in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i 's_https://_http://_' /etc/yum.repos.d/rcm-tools-fedora.repo
 COPY yum-packages.txt /tmp/yum-packages.txt
 
 RUN \
-    dnf -y install $(cat /tmp/yum-packages.txt) python3-rhmsg && \
+    dnf -y install $(cat /tmp/yum-packages.txt) python3-rhmsg findutils && \
     dnf clean all
 
 WORKDIR /src


### PR DESCRIPTION
Install find in the Freshmaker container for the possibility to create
an OpenShift CronJob to delete cassettes on the persistent volume that
are older than two weeks.

JIRA: https://projects.engineering.redhat.com/browse/CLOUDWF-1937