### PR TITLE
Filter images by builds in advisory for non-CVE advisories

### DIFF
--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -414,6 +414,11 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
         # Get srpm nvrs which are affected by the CVEs in this advisory
         srpm_nvrs = self.event.advisory.affected_srpm_nvrs
 
+        # If there is no CVE affected srpms, this can be non-RHSA advisory,
+        # just rebuild images that have the builds in this advisory installed
+        if not srpm_nvrs:
+            srpm_nvrs = list(errata.get_builds(errata_id))
+
         self.log_info(
             "Going to find all the container images to rebuild as "
             "result of %r update.", srpm_nvrs)


### PR DESCRIPTION
Fixed a regression in 3726cd4, after changing to use CVE mapping
feature from errata, the case of non-CVE advisory triggered rebuilds
will not work, this is a case in E2E testing. Put the code back to
fix it.