### PR TITLE
Use binary rpms for filtering images

### DIFF
--- a/dev_scripts/template_errata.py
+++ b/dev_scripts/template_errata.py
@@ -24,5 +24,5 @@ conf.errata_tool_server_url = sys.argv[1]
 errata = Errata()
 
 # Example usage:
-data = errata.get_builds(42515)
+data = errata.get_srpm_nvrs(42515)
 pprint(data)

--- a/freshmaker/handlers/koji/rebuild_images_on_parent_image_build.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_parent_image_build.py
@@ -176,17 +176,13 @@ class RebuildImagesOnParentImageBuild(ContainerBuildHandler):
         # and use set of the nvrs as a value.
         advisory_rpms_by_name = {}
         e = Errata()
-        build_nvrs = e.get_builds(errata_id)
-        if build_nvrs:
-            with koji_service(
-                    conf.koji_profile, log, login=False,
-                    dry_run=self.dry_run) as session:
-                for build_nvr in build_nvrs:
-                    build_rpms = session.get_build_rpms(build_nvr)
-                    for rpm in build_rpms:
-                        if rpm['name'] not in advisory_rpms_by_name:
-                            advisory_rpms_by_name[rpm['name']] = set()
-                        advisory_rpms_by_name[rpm['name']].add(rpm['nvr'])
+        binary_rpm_nvrs = e.get_binary_rpm_nvrs(errata_id)
+        if binary_rpm_nvrs:
+            for nvr in binary_rpm_nvrs:
+                parsed_nvr = rpmlib.parse_nvr(nvr)
+                if parsed_nvr['name'] not in advisory_rpms_by_name:
+                    advisory_rpms_by_name[parsed_nvr['name']] = set()
+                advisory_rpms_by_name[parsed_nvr['name']].add(nvr)
 
         # get rpms in container
         with koji_service(

--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -411,19 +411,19 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
         if isinstance(self.event, ManualRebuildWithAdvisoryEvent):
             leaf_container_images = self.event.container_images
 
-        # Get srpm nvrs which are affected by the CVEs in this advisory
-        srpm_nvrs = self.event.advisory.affected_srpm_nvrs
+        # Get binary rpm nvrs which are affected by the CVEs in this advisory
+        affected_nvrs = self.event.advisory.affected_rpm_nvrs
 
-        # If there is no CVE affected srpms, this can be non-RHSA advisory,
+        # If there is no CVE affected binary rpms, this can be non-RHSA advisory,
         # just rebuild images that have the builds in this advisory installed
-        if not srpm_nvrs:
-            srpm_nvrs = list(errata.get_builds(errata_id))
+        if not affected_nvrs:
+            affected_nvrs = errata.get_binary_rpm_nvrs(errata_id)
 
         self.log_info(
             "Going to find all the container images to rebuild as "
-            "result of %r update.", srpm_nvrs)
+            "result of %r update.", affected_nvrs)
         batches = lb.find_images_to_rebuild(
-            srpm_nvrs, content_sets,
+            affected_nvrs, content_sets,
             filter_fnc=self._filter_out_not_allowed_builds,
             published=published, release_categories=release_categories,
             leaf_container_images=leaf_container_images)

--- a/freshmaker/image_verifier.py
+++ b/freshmaker/image_verifier.py
@@ -171,7 +171,7 @@ class ImageVerifier(object):
         self._verify_repository_data(repo)
 
         rebuildable_images = {}
-        images = self.lb.find_images_with_included_srpms(
+        images = self.lb.find_images_with_included_rpms(
             [], [], {repo["repository"]: repo}, include_rpm_manifest=False)
         for image in images:
             self._verify_image_data(image)

--- a/freshmaker/odcsclient.py
+++ b/freshmaker/odcsclient.py
@@ -239,7 +239,7 @@ class FreshmakerODCSClient(object):
 
         packages = []
         errata = Errata()
-        builds = errata.get_builds(errata_id)
+        builds = errata.get_srpm_nvrs(errata_id)
         compose_source = None
         for nvr in builds:
             packages += self._get_packages_for_compose(nvr)

--- a/tests/handlers/koji/test_rebuild_images_on_parent_image_build.py
+++ b/tests/handlers/koji/test_rebuild_images_on_parent_image_build.py
@@ -208,12 +208,12 @@ class TestRebuildImagesOnParentImageBuild(helpers.ModelsTestCase):
                          self.db_advisory_rpm_signed_event.state)
 
     @mock.patch('freshmaker.kojiservice.KojiService')
-    @mock.patch('freshmaker.errata.Errata.get_builds')
-    def test_mark_build_done_when_container_has_latest_rpms_from_advisory(self, errata_get_builds, KojiService):
+    @mock.patch('freshmaker.errata.Errata.get_binary_rpm_nvrs')
+    def test_mark_build_done_when_container_has_latest_rpms_from_advisory(self, get_binary_rpm_nvrs, KojiService):
         """
         Tests when dependency container build task failed in brew, only update build state in db.
         """
-        errata_get_builds.return_value = set(['foo-1.2.1-22.el7'])
+        get_binary_rpm_nvrs.return_value = set(['foo-1.2.1-22.el7'])
 
         koji_service = KojiService.return_value
         koji_service.get_build_rpms.return_value = [
@@ -236,12 +236,12 @@ class TestRebuildImagesOnParentImageBuild(helpers.ModelsTestCase):
         self.assertEqual(build.state_reason, 'Built successfully.')
 
     @mock.patch('freshmaker.kojiservice.KojiService')
-    @mock.patch('freshmaker.errata.Errata.get_builds')
-    def test_mark_build_fail_when_container_not_has_latest_rpms_from_advisory(self, errata_get_builds, KojiService):
+    @mock.patch('freshmaker.errata.Errata.get_binary_rpm_nvrs')
+    def test_mark_build_fail_when_container_not_has_latest_rpms_from_advisory(self, get_binary_rpm_nvrs, KojiService):
         """
         Tests when dependency container build task failed in brew, only update build state in db.
         """
-        errata_get_builds.return_value = set(['foo-1.2.1-23.el7'])
+        get_binary_rpm_nvrs.return_value = set(['foo-1.2.1-23.el7'])
 
         koji_service = KojiService.return_value
         koji_service.get_build_rpms.return_value = [

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -436,7 +436,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             return_value=["pulp_repo_x86_64"])
 
         self.get_affected_srpm_nvrs = self.patcher.patch(
-            'freshmaker.errata.Errata.get_cve_affected_srpm_nvrs',
+            'freshmaker.errata.Errata.get_cve_affected_rpm_nvrs',
             return_value=["httpd-2.4-11.el7"])
 
         self.find_images_to_rebuild = self.patcher.patch(
@@ -553,11 +553,11 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             'image': {'advisory_name': 'RHBA-*'}
         }
     })
-    @patch("freshmaker.errata.ErrataAdvisory.affected_srpm_nvrs",
+    @patch("freshmaker.errata.ErrataAdvisory.affected_rpm_nvrs",
            new_callable=PropertyMock,
            return_value=["nodejs-10.19.0-1.module+el8.1.0+5726+6ed65f8c.x86_64"])
     @patch('os.path.exists', return_value=True)
-    def test_affected_packages_with_modules(self, exists, affected_srpm_nvrs):
+    def test_affected_packages_with_modules(self, exists, affected_rpm_nvrs):
         self.handler._find_images_to_rebuild(123456)
 
         self.find_images_to_rebuild.assert_called_once_with(

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -351,24 +351,27 @@ class TestErrata(helpers.FreshmakerTestCase):
 
     @patch.object(Errata, "_errata_rest_get")
     @patch.object(Errata, "_errata_http_get")
-    def test_get_builds(
+    def test_get_nvrs(
             self, errata_http_get, errata_rest_get):
         MockedErrataAPI(errata_rest_get, errata_http_get)
-        ret = self.errata.get_builds(28484, "")
-        self.assertEqual(ret, set(['libntirpc-1.4.3-4.el7rhgs',
-                                  'libntirpc-1.4.3-4.el6rhs']))
+        srpms = self.errata.get_srpm_nvrs(28484, "")
+        binary_rpms = self.errata.get_binary_rpm_nvrs(28484)
+        self.assertEqual(set(srpms), set(['libntirpc-1.4.3-4.el7rhgs',
+                                          'libntirpc-1.4.3-4.el6rhs']))
+        self.assertEqual(set(binary_rpms), set(['libntirpc-devel-1.4.3-4.el6rhs',
+                                                'libntirpc-devel-1.4.3-4.el7rhgs']))
 
     @patch.object(Errata, "_errata_rest_get")
     @patch.object(Errata, "_errata_http_get")
-    def test_get_builds_rhel_7(
+    def test_get_binary_rpms_rhel_7(
             self, errata_http_get, errata_rest_get):
         MockedErrataAPI(errata_rest_get, errata_http_get)
-        ret = self.errata.get_builds(28484, "RHEL-7")
-        self.assertEqual(ret, set(['libntirpc-1.4.3-4.el7rhgs']))
+        ret = self.errata.get_binary_rpm_nvrs(28484, "RHEL-7")
+        self.assertEqual(ret, ['libntirpc-devel-1.4.3-4.el7rhgs'])
 
     @patch.object(Errata, "_errata_rest_get")
     @patch.object(Errata, "_errata_http_get")
-    def test_get_builds_no_srpm(
+    def test_get_srpm_nvrs_empty(
             self, errata_http_get, errata_rest_get):
         api = MockedErrataAPI(errata_rest_get, errata_http_get)
         api.builds_json = {
@@ -382,14 +385,34 @@ class TestErrata(helpers.FreshmakerTestCase):
                 }
             ]
         }
-        ret = self.errata.get_builds(28484, "")
-        self.assertEqual(ret, set(['libntirpc-1.4.3-4.el7rhgs']))
+        ret = self.errata.get_srpm_nvrs(28484, "")
+        self.assertEqual(ret, [])
 
     @patch.object(Errata, "_errata_rest_get")
     @patch.object(Errata, "_errata_http_get")
-    def test_errata_get_cve_affected_srpm_nvrs(self, errata_http_get, errata_rest_get):
+    def test_get_binary_nvrs_empty(
+            self, errata_http_get, errata_rest_get):
+        api = MockedErrataAPI(errata_rest_get, errata_http_get)
+        api.builds_json = {
+            "PRODUCT1": [
+                {
+                    "libntirpc-1.4.3-4.el7rhgs":
+                        {
+                            "PRODUCT2-3.2-NFS":
+                                {"SRPMS": [
+                                    "libntirpc-devel-1.4.3-4.el7rhgs.x86_64.rpm"]}
+                        }
+                }
+            ]
+        }
+        ret = self.errata.get_binary_rpm_nvrs(28484, "")
+        self.assertEqual(ret, [])
+
+    @patch.object(Errata, "_errata_rest_get")
+    @patch.object(Errata, "_errata_http_get")
+    def test_errata_get_cve_affected_rpm_nvrs(self, errata_http_get, errata_rest_get):
         MockedErrataAPI(errata_rest_get, errata_http_get)
-        ret = self.errata.get_cve_affected_srpm_nvrs(28484)
+        ret = self.errata.get_cve_affected_rpm_nvrs(28484)
         self.assertEqual(ret, ['libntirpc-1.4.3-4.el6rhs'])
 
     def test_get_docker_repo_tags(self):

--- a/tests/test_image_verifier.py
+++ b/tests/test_image_verifier.py
@@ -94,7 +94,7 @@ class TestImageVerifier(helpers.FreshmakerTestCase):
                 "auto_rebuild_tags": ["latest"]
             })
         ]
-        self.lb.find_images_with_included_srpms.return_value = [
+        self.lb.find_images_with_included_rpms.return_value = [
             ContainerImage({
                 "brew": {"build": "foo-1-1"},
                 "content_sets": []
@@ -113,7 +113,7 @@ class TestImageVerifier(helpers.FreshmakerTestCase):
                 "auto_rebuild_tags": ["latest"]
             })
         ]
-        self.lb.find_images_with_included_srpms.return_value = [
+        self.lb.find_images_with_included_rpms.return_value = [
             ContainerImage({
                 "brew": {"build": "foo-1-1"},
                 "content_sets": ["content-set"]

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -164,11 +164,15 @@ class TestContainerImageObject(helpers.FreshmakerTestCase):
                 'rpms': [
                     {
                         "srpm_name": "openssl",
-                        "srpm_nevra": "openssl-0:1.2.3-1.src"
+                        "srpm_nevra": "openssl-0:1.2.3-1.src",
+                        "name": "openssl",
+                        "nvra": "openssl-1.2.3-1.amd64"
                     },
                     {
                         "srpm_name": "tespackage",
-                        "srpm_nevra": "testpackage-10:1.2.3-1.src"
+                        "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                        "name": "tespackage",
+                        "nvra": "testpackage-1.2.3-1.amd64"
                     }
                 ]
             }]
@@ -574,11 +578,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src"
+                            "srpm_nevra": "openssl-0:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.amd64"
                         },
                         {
                             "srpm_name": "tespackage",
-                            "srpm_nevra": "testpackage-10:1.2.3-1.src"
+                            "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                            "name": "tespackage",
+                            "nvra": "testpackage-1.2.3-1.amd64"
                         }
                     ]
                 }]
@@ -613,11 +621,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-1:1.2.3-1.src"
+                            "srpm_nevra": "openssl-1:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.amd64"
                         },
                         {
                             "srpm_name": "tespackage2",
-                            "srpm_nevra": "testpackage2-10:1.2.3-1.src"
+                            "srpm_nevra": "testpackage2-10:1.2.3-1.src",
+                            "name": "tespackage2",
+                            "nvra": "testpackage2-1.2.3-1.amd64"
                         }
                     ]
                 }]
@@ -651,11 +663,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src"
+                            "srpm_nevra": "openssl-0:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.amd64"
                         },
                         {
                             "srpm_name": "tespackage",
-                            "srpm_nevra": "testpackage-10:1.2.3-1.src"
+                            "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                            "name": "tespackage",
+                            "nvra": "testpackage-1.2.3-1.amd64"
                         }
                     ]
                 }]
@@ -689,11 +705,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-1.2.1-2.module+el8.0.0+3248+9d514f3b.src"
+                            "srpm_nevra": "openssl-1.2.1-2.module+el8.0.0+3248+9d514f3b.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.1-2.module+el8.0.0+3248+9d514f3b.amd64"
                         },
                         {
                             "srpm_name": "tespackage",
-                            "srpm_nevra": "testpackage-10:1.2.3-1.src"
+                            "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                            "name": "tespackage",
+                            "nvra": "testpackage-1.2.3-1.amd64"
                         }
                     ]
                 }]
@@ -727,12 +747,16 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                 'rpm_manifest': [{
                     'rpms': [
                         {
-                            'srpm_name': 'openssl',
-                            'srpm_nevra': 'openssl-0:1.2.3-1.src'
+                            "srpm_name": "openssl",
+                            "srpm_nevra": "openssl-0:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.amd64"
                         },
                         {
-                            'srpm_name': 'tespackage',
-                            'srpm_nevra': 'testpackage-10:1.2.3-1.src'
+                            "srpm_name": "tespackage",
+                            "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                            "name": "tespackage",
+                            "nvra": "testpackage-1.2.3-1.amd64"
                         }
                     ]
                 }]
@@ -1082,7 +1106,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         # Add a duplicate simulating a multi-arch image
         self.fake_container_images.append(self.fake_container_images[1])
         cont_images.return_value = self.fake_container_images
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2"], repositories)
 
         expected_image_request = {
@@ -1130,7 +1154,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     {
                         "$or": [
                             {
-                                "field": "rpm_manifest.*.rpms.*.srpm_name",
+                                "field": "rpm_manifest.*.rpms.*.name",
                                 "op": "=",
                                 "rvalue": "openssl"
                             },
@@ -1143,7 +1167,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     },
                 ]
             },
-            "projection": lb._get_default_projection(srpm_names=["openssl"])
+            "projection": lb._get_default_projection(rpm_names=["openssl"])
         }
 
         # auto_rebuild_tags is a set in the source code. When generate
@@ -1177,7 +1201,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         cont_images.return_value = (
             self.fake_container_images +
             self.fake_container_images_floating_tag)
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2"], repositories)
 
         self.assertEqual(
@@ -1199,7 +1223,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         cont_images.return_value = (
             self.fake_container_images +
             self.fake_container_images_floating_tag)
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["content-set-1", "content-set-2"], ["openssl-1.2.3-1"], repositories)
         self.assertEqual(ret, [])
 
@@ -1218,7 +1242,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         cont_images.return_value = (
             self.fake_container_images +
             self.fake_container_images_floating_tag)
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"],
             ["openssl-1.2.3-1", "openssl-1.2.3-50"], repositories)
         self.assertEqual(
@@ -1312,11 +1336,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                                      'rpms': [
                                          {
                                              "srpm_name": "openssl",
-                                             "srpm_nevra": "openssl-1:1.2.3-1.src"
+                                             "srpm_nevra": "openssl-1:1.2.3-1.src",
+                                             "name": "openssl",
+                                             "nvra": "openssl-1.2.3-1.amd64"
                                          },
                                          {
                                              "srpm_name": "tespackage2",
-                                             "srpm_nevra": "testpackage2-10:1.2.3-1.src"
+                                             "srpm_nevra": "testpackage2-10:1.2.3-1.src",
+                                             "name": "tespackage2",
+                                             "nvra": "testpackage2-1.2.3-1.amd64"
                                          }
                                      ]
                                  }]
@@ -1419,11 +1447,15 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                                      'rpms': [
                                          {
                                              "srpm_name": "openssl",
-                                             "srpm_nevra": "openssl-1:1.2.3-1.src"
+                                             "srpm_nevra": "openssl-1:1.2.3-1.src",
+                                             "name": "openssl",
+                                             "nvra": "openssl-1.2.3-1.amd64"
                                          },
                                          {
                                              "srpm_name": "tespackage2",
-                                             "srpm_nevra": "testpackage2-10:1.2.3-1.src"
+                                             "srpm_nevra": "testpackage2-10:1.2.3-1.src",
+                                             "name": "tespackage2",
+                                             "nvra": "testpackage2-1.2.3-1.amd64"
                                          }
                                      ]
                                  }]
@@ -1663,7 +1695,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         for image in images:
             image["rpm_manifest"] = [{
                 "rpms": [
-                    {"srpm_name": "dummy"}
+                    {"name": "dummy"}
                 ]
             }]
             image["directly_affected"] = True
@@ -1762,7 +1794,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "repositories": [{"repository": "foo/bar"}],
             "rpm_manifest": [{
                 "rpms": [
-                    {"srpm_name": "dummy"}
+                    {"name": "dummy"}
                 ]
             }]
         })
@@ -1788,8 +1820,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             find_images_with_packages_from_content_set, get_images_by_nvrs):
         exists.return_value = True
 
-        vulnerable_srpm_name = 'oh-noes'
-        vulnerable_srpm_nvr = '{}-1.0-1'.format(vulnerable_srpm_name)
+        vulnerable_rpm_name = 'oh-noes'
+        vulnerable_rpm_nvr = '{}-1.0-1'.format(vulnerable_rpm_name)
 
         ubi_image_template = {
             "brew": {"package": "ubi8-container", "build": "ubi8-container-8.1-100"},
@@ -1799,7 +1831,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "repositories": [{"repository": "ubi8"}],
             "rpm_manifest": [{
                 "rpms": [
-                    {"srpm_name": vulnerable_srpm_name}
+                    {"name": vulnerable_rpm_name}
                 ]
             }]
         }
@@ -1822,7 +1854,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "repositories": [{"repository": "ubi8/python-36"}],
             "rpm_manifest": [{
                 "rpms": [
-                    {"srpm_name": vulnerable_srpm_name}
+                    {"name": vulnerable_rpm_name}
                 ]
             }]
         })
@@ -1835,7 +1867,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "repositories": [{"repository": "ubi8/nodejs-12"}],
             "rpm_manifest": [{
                 "rpms": [
-                    {"srpm_name": vulnerable_srpm_name}
+                    {"name": vulnerable_rpm_name}
                 ]
             }]
         })
@@ -1868,7 +1900,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         lb = LightBlue(server_url=self.fake_server_url,
                        cert=self.fake_cert_file,
                        private_key=self.fake_private_key)
-        batches = lb.find_images_to_rebuild([vulnerable_srpm_nvr], [vulnerable_srpm_name])
+        batches = lb.find_images_to_rebuild([vulnerable_rpm_nvr], [vulnerable_rpm_name])
         expected_batches = [
             # The dependency ubi image has a higher NVR and it should be used as
             # the parent for both images.
@@ -1978,7 +2010,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                         {'field': 'brew.build', 'rvalue': 'bar', 'op': '='}]},
                     {'field': 'parsed_data.files.*.key', 'rvalue': 'buildfile', 'op': '='},
                     {'$or': [{'field': 'content_sets.*', 'rvalue': 'dummy-content-set', 'op': '='}]},
-                    {'$or': [{'field': 'rpm_manifest.*.rpms.*.srpm_name', 'rvalue': 'openssl', 'op': '='}]}]},
+                    {'$or': [{'field': 'rpm_manifest.*.rpms.*.name', 'rvalue': 'openssl', 'op': '='}]}]},
              'projection': [{'field': 'brew', 'include': True, 'recursive': True},
                             {'field': 'parsed_data.files', 'include': True, 'recursive': True},
                             {'field': 'parsed_data.layers.*', 'include': True, 'recursive': True},
@@ -1991,6 +2023,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                             {'field': 'architecture', 'include': True, 'recursive': False},
                             {'field': 'rpm_manifest.*.rpms.*.srpm_nevra', 'include': True, 'recursive': True},
                             {'field': 'rpm_manifest.*.rpms.*.nvra', 'include': True, 'recursive': True},
+                            {'field': 'rpm_manifest.*.rpms.*.name', 'include': True, 'recursive': True},
                             {'field': 'rpm_manifest.*.rpms.*.srpm_name', 'include': True, 'recursive': True}],
              'objectType': 'containerImage'})
 
@@ -2016,7 +2049,9 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src"
+                            "srpm_nevra": "openssl-0:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.amd64"
                         }
                     ]
                 }],
@@ -2039,7 +2074,9 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     'rpms': [
                         {
                             "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src"
+                            "srpm_nevra": "openssl-0:1.2.3-1.src",
+                            "name": "openssl",
+                            "nvra": "openssl-1.2.3-1.s390x"
                         }
                     ]
                 }],
@@ -2080,12 +2117,12 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             self.fake_repositories_with_content_sets}
         cont_images.return_value = (
             self.fake_images_with_modules)
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2.module+el8.0.0+3248+9d514f3b.src"], repositories)
         self.assertEqual(
             [image.nvr for image in ret],
             ["package-name-3-4-12.10"])
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2.el8.0.0+3248+9d514f3b.src"], repositories)
         self.assertEqual(
             [image.nvr for image in ret],
@@ -2118,8 +2155,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "content_sets": ["dummy-content-set-2"]})
         cont_images.return_value = [parent, latest_parent, older_parent]
 
-        ret = lb.find_images_with_included_srpms(
-            ["dummy-content-set-1"], ["openssl-1.2.3-2.module+el8.0.0+3248+9d514f3b.src"], repositories)
+        ret = lb.find_images_with_included_rpms(
+            ["dummy-content-set-1"], ["openssl-1.2.3-2.module+el8.0.0+3248+9d514f3b"], repositories)
         self.assertEqual(
             [image.nvr for image in ret],
             ["parent-1-2", "parent-1-3"])
@@ -2152,7 +2189,9 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                 'rpms': [
                     {
                         "srpm_name": "openssl",
-                        "srpm_nevra": "openssl-0:1.2.3-1.src"
+                        "srpm_nevra": "openssl-0:1.2.3-1.src",
+                        "name": "openssl",
+                        "nvra": "openssl-1.2.3-1.amd64"
                     }
                 ]
             }],
@@ -2162,7 +2201,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         self.fake_container_images.append(build_repo_image)
         find_images.return_value = self.fake_container_images
 
-        ret = lb.find_images_with_included_srpms(
+        ret = lb.find_images_with_included_rpms(
             ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2"], repositories)
 
         self.assertEqual(ret, [find_images.return_value[1], find_images.return_value[-1]])
@@ -2172,7 +2211,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         with patch.object(
             freshmaker.conf, "image_build_repository_registries", new=build_registries
         ):
-            ret = lb.find_images_with_included_srpms(
+            ret = lb.find_images_with_included_rpms(
                 ["dummy-content-set-1", "dummy-content-set-2"], ["openssl-1.2.3-2"], repositories)
 
         self.assertEqual(ret, [find_images.return_value[1]])

--- a/tests/test_odcsclient.py
+++ b/tests/test_odcsclient.py
@@ -174,7 +174,7 @@ class TestPrepareYumRepo(helpers.ModelsTestCase):
             "state_name": "wait",
         }
 
-        errata.return_value.get_builds.return_value = set(["httpd-2.4.15-1.f27"])
+        errata.return_value.get_srpm_nvrs.return_value = set(["httpd-2.4.15-1.f27"])
 
         handler = MyHandler()
         compose = handler.odcs.prepare_yum_repo(self.ev)
@@ -207,7 +207,7 @@ class TestPrepareYumRepo(helpers.ModelsTestCase):
         _get_compose_source.side_effect = [
             'rhel-7.2-candidate', 'rhel-7.7-candidate']
 
-        errata.return_value.get_builds.return_value = [
+        errata.return_value.get_srpm_nvrs.return_value = [
             set(["httpd-2.4.15-1.f27"]), set(["foo-2.4.15-1.f27"])]
 
         handler = MyHandler()
@@ -233,7 +233,7 @@ class TestPrepareYumRepo(helpers.ModelsTestCase):
         _get_packages_for_compose.return_value = ['httpd', 'httpd-debuginfo']
         _get_compose_source.return_value = None
 
-        errata.return_value.get_builds.return_value = [
+        errata.return_value.get_srpm_nvrs.return_value = [
             set(["httpd-2.4.15-1.f27"]), set(["foo-2.4.15-1.f27"])]
 
         handler = MyHandler()


### PR DESCRIPTION
Now we will use binary rpms instead of SRPMs to filter images. It's
possible due to new functionality in ET, allowing us to get binary rpms
 affected by CVEs in an advisory straight from ET.

RESOLVE CLOUDWF-2968

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>