### PR TITLE
Exclude images from build repositories

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -271,6 +271,10 @@ class Config(object):
                     'for other images. WARN: This may lead to downgrade to older '
                     'release as result of rebuild when image to rebuild depends '
                     'on unreleased release of the parent image.'},
+        'image_build_repository_registries': {
+            'type': list,
+            'default': [],
+            'desc': 'List of image build repository registries.'},
         'errata_tool_server_url': {
             'type': str,
             'default': '',

--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -705,6 +705,7 @@ class LightBlue(object):
             {"field": "parsed_data.files", "include": True, "recursive": True},
             {"field": "parsed_data.layers.*", "include": True, "recursive": True},
             {"field": "repositories.*.published", "include": True, "recursive": True},
+            {"field": "repositories.*.registry", "include": True, "recursive": True},
             {"field": "repositories.*.repository", "include": True, "recursive": True},
             {"field": "repositories.*.tags.*.name", "include": True, "recursive": True},
             {"field": "content_sets", "include": True, "recursive": True},
@@ -960,6 +961,10 @@ class LightBlue(object):
 
             for repository in image["repositories"]:
                 if repository["repository"] not in repositories:
+                    continue
+
+                # skip images from build repositories
+                if repository["registry"] in conf.image_build_repository_registries:
                     continue
 
                 published_repo = repositories[repository["repository"]]


### PR DESCRIPTION
Images from build repositories should not be include in our rebuild
list, to filter out these images, we have a new configurable
"IMAGE_BUILD_REPOSITORY_REGISTRIES" which can be set in config.py,
it's a list of build repository registries. If an image's repository
registry is in this list, the image will be excluded.

JIRA: CLOUDWF-3094