### PR TITLE
Improve return messages for verify-image-repository API

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -549,13 +549,14 @@ class LightBlue(object):
         else:
             raise LightBlueRequestError(status_code, response.json())
 
-    def find_container_repositories(self, request):
+    def find_container_repositories(self, request, auto_rebuild=True):
         """Query via entity containerRepository
 
         :param dict request: a map containing complete query expression.
             This query will be sent to LightBlue in a POST request. Refer to
             https://jewzaam.gitbooks.io/lightblue-specifications/content/language_specification/query.html
             to know more detail about how to write a query.
+        :param bool auto_rebuild: only include repositories that have auto_rebuild_tags set.
         :return: a list of ContainerRepository objects
         :rtype: list
         """
@@ -566,7 +567,7 @@ class LightBlue(object):
 
         repos = []
         for repo_data in response['processed']:
-            if not repo_data.get('auto_rebuild_tags'):
+            if auto_rebuild and not repo_data.get('auto_rebuild_tags'):
                 log.info('"auto_rebuild_tags" not set for %s repository, ignoring repository',
                          repo_data["repository"])
                 continue

--- a/freshmaker/views.py
+++ b/freshmaker/views.py
@@ -706,11 +706,22 @@ class VerifyImageRepositoryAPI(MethodView):
         .. sourcecode:: none
 
             {
+                "repository: {
+                    "auto_rebuild_tags": [
+                        "latest"
+                    ],
+                },
                 "images": {
-                    "foo-1-1": [
-                        "content-set-1",
-                        "content-set-2"
-                    ]
+                    "foo-1-1": {
+                        "content_sets": [
+                            "content-set-1",
+                            "content-set-2"
+                        ],
+                        "tags": [
+                            "latest",
+                            "2.0"
+                        ]
+                    }
                 },
                 "msg": "Found 1 images which are handled by Freshmaker."
             }
@@ -723,11 +734,12 @@ class VerifyImageRepositoryAPI(MethodView):
             raise ValueError("No image repository name provided")
 
         verifier = ImageVerifier()
-        images = verifier.verify_repository("%s/%s" % (project, repo))
+        data = verifier.verify_repository("%s/%s" % (project, repo))
         ret = {
             "msg": "Found %d images which are handled by Freshmaker for "
-                   "defined content_sets." % len(images),
-            "images": images,
+                   "defined content_sets." % len(data["images"]),
+            "images": data["images"],
+            "repository": data["repository"]
         }
         return jsonify(ret), 200
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -609,12 +609,26 @@ class TestViews(helpers.ModelsTestCase):
     @patch("freshmaker.views.ImageVerifier")
     def test_verify_image_repository(self, verifier):
         verifier.return_value.verify_repository.return_value = {
-            "foo-1-1": ["content-set"]}
-        resp = self.client.get('/api/1/verify-image-repository/foo/bar')
+            "repository": {"auto_rebuild_tags": ["latest"]},
+            "images": {
+                "foo-1-1": {"content_sets": ["content-set"], "tags": ["1", "latest", "1-1"]}
+            }
+        }
+        resp = self.client.get("/api/1/verify-image-repository/foo/bar")
         data = resp.json
-        self.assertEqual(data, {
-            'images': {'foo-1-1': ['content-set']},
-            'msg': 'Found 1 images which are handled by Freshmaker for defined content_sets.'})
+        expected = {
+            "repository": {
+                "auto_rebuild_tags": ["latest"],
+            },
+            "images": {
+                "foo-1-1": {
+                    "tags": ["1", "latest", "1-1"],
+                    "content_sets": ["content-set"]
+                }
+            },
+            "msg": "Found 1 images which are handled by Freshmaker for defined content_sets."
+        }
+        self.assertEqual(data, expected)
 
     def test_dependencies(self):
         event = models.Event.create(db.session, "2017-00000000-0000-0000-0000-000000000003", "103", events.TestingEvent)


### PR DESCRIPTION
When image repository doesn't have auto_rebuild_tags set, the return
message of verify-image-repository API tells user the repository doesn't
exist, like this:

    {
        "error": "Bad Request",
        "message": "Cannot get repository foo/bar from Lightblue.",
        "status": 400
    }

Instead of this message, freshmaker should tells users that this
repository doesn't have auto_rebuild_tags set. After change, the return
message will be something like:

    {
        "error": "Bad Request",
        "message": "The \"auto_rebuild_tags\" in COMET is not set.",
        "status": 400
    }

In this change, the return message is changed to include more info about
the repository and the rebuildable images, including the 'auto_rebuilds_tags'
for repository and tags of image. Something like this:

    {
        "auto_rebuild_tags": [
            "latest"
        ],
        "images": {
            "foobar-1-123": {
                "content_sets": [
                    "content-set-1",
                    "content-set-2"
                ],
                "tags": [
                    "latest",
                    "1-123"
                ]
            }
        },
        "msg": "Found 1 images which are handled by Freshmaker for defined content_sets."
    }

JIRA: CLOUDWF-3237