### PR TITLE
Use publicly available copr repo for python-rhsm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# ignore .git folder because we don't need it
+.git


### PR DESCRIPTION
Now we will use publicly available copr repo for python-rhmsg, because we
need it to use quay.io build. So now we can build Freshmaker image on
quay.io. And so we don't have any internal packages dependencies.

And for now we don't have solution on how to create lable with git commit hash, so I removed that functionality for now. Because Quay doesn't support build-arg for docker build.

RESOLVE: CLOUDWF-2607

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>