### PR TITLE
Include images without Dockerfile in dist-git repo

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -906,11 +906,6 @@ class LightBlue(object):
                             "rvalue": tag
                         } for tag in auto_rebuild_tags]
                     },
-                    {
-                        "field": "parsed_data.files.*.key",
-                        "op": "=",
-                        "rvalue": "buildfile"
-                    },
                 ]
             },
             "projection": self._get_default_projection(
@@ -1020,11 +1015,6 @@ class LightBlue(object):
                             "op": "=",
                             "rvalue": nvr
                         } for nvr in nvrs]
-                    },
-                    {
-                        "field": "parsed_data.files.*.key",
-                        "op": "=",
-                        "rvalue": "buildfile"
                     },
                 ]
             },

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -1133,11 +1133,6 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                         ],
                     },
                     {
-                        "field": "parsed_data.files.*.key",
-                        "op": "=",
-                        "rvalue": "buildfile"
-                    },
-                    {
                         "$or": [
                             {
                                 "field": "content_sets.*",
@@ -2008,7 +2003,6 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                     {'$or': [
                         {'field': 'brew.build', 'rvalue': 'foo', 'op': '='},
                         {'field': 'brew.build', 'rvalue': 'bar', 'op': '='}]},
-                    {'field': 'parsed_data.files.*.key', 'rvalue': 'buildfile', 'op': '='},
                     {'$or': [{'field': 'content_sets.*', 'rvalue': 'dummy-content-set', 'op': '='}]},
                     {'$or': [{'field': 'rpm_manifest.*.rpms.*.name', 'rvalue': 'openssl', 'op': '='}]}]},
              'projection': [{'field': 'brew', 'include': True, 'recursive': True},


### PR DESCRIPTION
While querying images from LightBlue, Freshmaker has such a filter to
filter out images which don't have Dockerfile in dist-git repos:

    {
        "field": "parsed_data.files.*.key",
        "op": "=",
        "rvalue": "buildfile"
    },

When an image has Dockerfile in its dist-git repo, the saved metadata in
LighBlue will include something like this:

    "parsed_data": {
        "files": [
            {
                "content_url": "http://dist-git.example.com/testimage/plain/Dockerfile?id=242a0a1e38ca1c31db070b687f68e7e6afc05d43",
                "filename": "Dockerfile",
                "key": "buildfile"
            },
        ],
        ...
    }

For some images, they don't have Dockerfile in dist-git repo, but OSBS
can generate a Dockerfile based on the information in container.yaml, to
include these images in our rebuild list, in this commit, we removed the
query criteria of "buildfile" in parsed_data.files.

JIRA: CLOUDWF-3443