### PR TITLE
Botas advisory handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Freshmaker-status](https://quay.io/repository/factory2/freshmaker/status)](https://quay.io/repository/factory2/freshmaker)
 ![Freshmaker](https://github.com/redhat-exd-rebuilds/freshmaker/raw/master/logo.png)
 
 ## What is Freshmaker?

--- a/dev_scripts/botas_advisory_test.py
+++ b/dev_scripts/botas_advisory_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""
+Example usage:
+    ./botas_advisory_test.py ADVISORY_ID
+    ./botas_advisory_test.py 59808
+"""
+import os
+import sys
+from unittest.mock import patch
+from logging.config import dictConfig
+import fedmsg.config
+
+# Allow imports from parent directory.
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+# Set the FRESHMAKER_DEVELOPER_ENV variable.
+os.environ["FRESHMAKER_DEVELOPER_ENV"] = "1"
+os.environ["FRESHMAKER_CONFIG_FILE"] = os.path.join(sys.path[0], "config.py")
+os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-bundle.crt"
+
+from freshmaker import db, app
+from freshmaker.events import BotasErrataShippedEvent
+from freshmaker.handlers.botas.botas_shipped_advisory import HandleBotasAdvisory
+from freshmaker.errata import Errata, ErrataAdvisory
+
+
+fedmsg_config = fedmsg.config.load_config()
+dictConfig(fedmsg_config.get('logging', {'version': 1}))
+
+if len(sys.argv) != 2:
+    print("Usage: ./botas_advisory_test.py ADVISORY_ID")
+    sys.exit(1)
+
+app_context = app.app_context()
+app_context.__enter__()
+
+db.drop_all()
+db.create_all()
+db.session.commit()
+
+advisory_id = sys.argv[1]
+errata = Errata()
+advisory = ErrataAdvisory.from_advisory_id(errata, advisory_id)
+
+event = BotasErrataShippedEvent(msg_id='fake-msg', advisory=advisory,
+                                dry_run=True)
+
+handler = HandleBotasAdvisory()
+with patch("freshmaker.consumer.get_global_consumer"):
+    if handler.can_handle(event):
+        handler.handle(event)
+    else:
+        print("Can't handle that event")

--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -56,6 +56,7 @@ class ErrataAdvisory(object):
         self.has_hightouch_bug = has_hightouch_bug
 
         self._affected_rpm_nvrs = None
+        self._reporter = ""
 
     @property
     def affected_rpm_nvrs(self):
@@ -65,6 +66,16 @@ class ErrataAdvisory(object):
         errata = Errata()
         self._affected_rpm_nvrs = errata.get_cve_affected_rpm_nvrs(self.errata_id)
         return self._affected_rpm_nvrs
+
+    @property
+    def reporter(self):
+        if self._reporter:
+            return self._reporter
+
+        errata = Errata()
+        advisory_data = errata._get_advisory_legacy(self.errata_id)
+        self._reporter = advisory_data['people']['reporter']
+        return self._reporter
 
     @classmethod
     def from_advisory_id(cls, errata, errata_id):
@@ -170,6 +181,9 @@ class Errata(object):
 
     def _get_advisory(self, errata_id):
         return self._errata_rest_get('erratum/{0}'.format(errata_id))
+
+    def _get_advisory_legacy(self, errata_id):
+        return self._errata_http_get('advisory/{0}.json'.format(errata_id))
 
     def _get_product(self, product_id):
         return self._errata_http_get("products/%s.json" % str(product_id))

--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -452,3 +452,10 @@ class FreshmakerAsyncManualBuildEvent(BaseEvent):
         self.brew_target = brew_target
         self.requester = requester
         self.requester_metadata_json = requester_metadata_json
+
+
+class BotasErrataShippedEvent(ErrataBaseEvent):
+    """ Event triggered, when BOTAS pushes advisory to SHIPPED_LIVE state """
+
+    def __init__(self, msg_id, advisory, dry_run=False):
+        super().__init__(msg_id, advisory, dry_run=dry_run)

--- a/freshmaker/handlers/botas/__init__.py
+++ b/freshmaker/handlers/botas/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020  Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .botas_shipped_advisory import HandleBotasAdvisory # noqa

--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020  Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from freshmaker import db
+from freshmaker.handlers import ContainerBuildHandler
+from freshmaker.events import BotasErrataShippedEvent
+from freshmaker.models import Event
+from freshmaker.types import EventState
+
+
+class HandleBotasAdvisory(ContainerBuildHandler):
+    """
+    Handles event that was created by transition of an advisory filed by
+    BOTAS to SHIPPED_LIVE state
+    """
+    name = "HandleBotasAdvisory"
+
+    def can_handle(self, event):
+        if (isinstance(event, BotasErrataShippedEvent) and
+                'docker' in event.advisory.content_types):
+            return True
+
+        return False
+
+    def handle(self, event):
+        if event.dry_run:
+            self.force_dry_run()
+        self.event = event
+
+        # Get event from database or create new one.
+        # Then we can get original NVRs from it.
+        db_event = Event.get_or_create_from_event(db.session, event)
+
+        self.set_context(db_event)
+
+        # Check if event is allowed by internal policies
+        if not self.event.is_allowed(self):
+            msg = ("This image rebuild is not allowed by internal policy. "
+                   f"message_id: {event.msg_id}")
+            db_event.transition(EventState.SKIPPED, msg)
+            db.session.commit()
+            self.log_info(msg)
+            return []
+
+        # Get original nvrs of all builds in the advisory
+        original_nvrs = [build.original_nvr for build in db_event.builds]
+        self.log_info(
+            "Orignial nvrs of build in the advisory #{0} are: {1}".format(
+                db_event.search_key, " ".join(original_nvrs)))
+
+        msg = "Skipping due to being blocked on further implementation for now."
+
+        # Skip that event because we can't proceed with processing it.
+        # TODO
+        # Next step would be queries Pyxis and getting the digests of these nvrs
+        db_event.transition(EventState.SKIPPED, msg)
+        db.session.commit()
+        return []

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -46,7 +46,7 @@ from freshmaker.events import (
     ErrataAdvisoryRPMsSignedEvent, BrewContainerTaskStateChangeEvent,
     ErrataAdvisoryStateChangedEvent, FreshmakerManualRebuildEvent,
     ODCSComposeStateChangeEvent, ManualRebuildWithAdvisoryEvent,
-    FreshmakerAsyncManualBuildEvent)
+    FreshmakerAsyncManualBuildEvent, BotasErrataShippedEvent)
 
 EVENT_TYPES = {
     MBSModuleStateChangeEvent: 0,
@@ -64,6 +64,7 @@ EVENT_TYPES = {
     ODCSComposeStateChangeEvent: 12,
     ManualRebuildWithAdvisoryEvent: 13,
     FreshmakerAsyncManualBuildEvent: 14,
+    BotasErrataShippedEvent: 15,
 }
 
 INVERSE_EVENT_TYPES = {v: k for k, v in EVENT_TYPES.items()}

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020  Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from freshmaker.events import (
+    BotasErrataShippedEvent,
+    ManualRebuildWithAdvisoryEvent,
+    ErrataAdvisoryRPMsSignedEvent)
+from freshmaker.handlers.botas import HandleBotasAdvisory
+from freshmaker.errata import ErrataAdvisory
+from tests import helpers
+
+
+class TestBotasShippedAdvisory(helpers.ModelsTestCase):
+
+    def setUp(self):
+        super(TestBotasShippedAdvisory, self).setUp()
+
+        # Each time when recording a build into database, freshmaker has to
+        # request a pulp repo from ODCS. This is not necessary for running
+        # tests.
+        self.patcher = helpers.Patcher(
+            'freshmaker.handlers.botas.botas_shipped_advisory.')
+
+        # We do not want to send messages to message bus while running tests
+        self.mock_messaging_publish = self.patcher.patch(
+            'freshmaker.messaging.publish')
+
+        self.botas_advisory = ErrataAdvisory(
+            123, "RHBA-2020", "SHIPPED_LIVE", ['docker'])
+        self.botas_advisory._reporter = "botas/pnt-devops-jenkins@REDHAT.COM"
+        self.rhba_event = ErrataAdvisoryRPMsSignedEvent(
+            "123", self.botas_advisory)
+
+    def tearDown(self):
+        super(TestBotasShippedAdvisory, self).tearDown()
+        self.patcher.unpatch_all()
+
+    def test_can_handle_botas_adisory(self):
+        event = BotasErrataShippedEvent("123", self.botas_advisory)
+        handler = HandleBotasAdvisory()
+        self.assertTrue(handler.can_handle(event))
+
+    def test_can_handle_manual_rebuild_with_advisory(self):
+        event = ManualRebuildWithAdvisoryEvent("123", self.botas_advisory, [])
+        handler = HandleBotasAdvisory()
+        self.assertFalse(handler.can_handle(event))

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -79,7 +79,10 @@ class MockedErrataAPI(object):
             "product": {
                 "id": 89,
                 "short_name": "product",
-            }
+            },
+            "people": {
+                "reporter": "botas/dev-jenkins.some.strange.letters.redhat.com@REDHAT.COM"
+            },
         }
 
         self.advisory_rest_json = {

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
 
 [pytest]
 addopts = --cov=freshmaker
+testpaths = tests
 
 [coverage:report]
 skip_covered = 1


### PR DESCRIPTION
Add new handler to handle advisories in SHIPPED_LIVE state
that were filed by BOTAS. We need that for future support of Operators CVE
rebuild functionality. To support rebuilding of Bundle images.
+ small badge to see container build status in Quay

RESOLVE: CLOUDWF-3611
