### PR TITLE
Query images from Lightblue only with RH vendor

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -271,6 +271,10 @@ class Config(object):
                     'for other images. WARN: This may lead to downgrade to older '
                     'release as result of rebuild when image to rebuild depends '
                     'on unreleased release of the parent image.'},
+        'lightblue_repo_vendors': {
+            'type': tuple,
+            'default': ("redhat",),
+            'desc': 'Allowed vendors for Container Repositories'},
         'image_build_repository_registries': {
             'type': list,
             'default': [],

--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -631,7 +631,8 @@ class LightBlue(object):
 
     def _set_container_repository_filters(
             self, request, published=True,
-            release_categories=conf.lightblue_release_categories):
+            release_categories=conf.lightblue_release_categories,
+            vendors=conf.lightblue_repo_vendors):
         """
         Sets the additional filters to containerRepository request
         based on the self.published, self.release_categories attributes.
@@ -640,6 +641,8 @@ class LightBlue(object):
         :param release_categories: filter only repositories with specific
             release categories (options: Deprecated, Generally Available, Beta, Tech Preview)
         :type release_categories: tuple[str] or list[str]
+        :param vendors: accept repositories only from selected vendors
+        :type vendors: tuple[str]
         """
         if published is not None:
             request["query"]["$and"].append({
@@ -655,6 +658,15 @@ class LightBlue(object):
                     "op": "=",
                     "rvalue": category
                 } for category in release_categories]
+            })
+
+        if vendors:
+            request["query"]["$and"].append({
+                "$or": [{
+                    "field": "vendorLabel",
+                    "op": "=",
+                    "rvalue": vendor
+                } for vendor in vendors]
             })
 
         return request

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -1076,6 +1076,11 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                             {"field": "release_categories.*", "rvalue": "Tech Preview", "op": "="},
                             {"field": "release_categories.*", "rvalue": "Beta", "op": "="}]
                     },
+                    {
+                        "$or": [
+                            {"field": "vendorLabel", "rvalue": "redhat", "op": "="},
+                        ]
+                    },
                 ]
             },
             "projection": [


### PR DESCRIPTION
Add 'vendor' parameter to Lightblue queries, so now we will get container images only with Red Hat vendor.

Resolves: CLOUDWF-3527

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>