### PR TITLE
Make _deduplicate_images_to_rebuild syntactically more concise

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -387,9 +387,7 @@ class ContainerImage(dict):
     def resolve(self, lb_instance, children=None):
         """
         Resolves the Container image - populates additional metadata by
-        querying Koji and dist-git.
-
-        Calls self.resolve_commit() and self.resolve_content_sets().
+        querying Koji and lightblue.
         """
         try:
             self.resolve_commit()


### PR DESCRIPTION
A separate commit also clarifies the docstring of `ContainerImage.resolve`.

I find this syntax a little easier to read, but if you disagree, we can close this PR.