### PR TITLE
Query bundles for the rebuilt operators/operands

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -251,6 +251,8 @@ class TestConfiguration(BaseConfiguration):
     LIGHTBLUE_SERVER_URL = ''  # replace with real dev server url
     LIGHTBLUE_VERIFY_SSL = False
 
+    PYXIS_SERVER_URL = 'https://localhost/'
+
     # Disable caching for tests
     DOGPILE_CACHE_BACKEND = "dogpile.cache.null"
 

--- a/dev_scripts/config.py.template
+++ b/dev_scripts/config.py.template
@@ -28,6 +28,9 @@ class BaseConfiguration(object):
     LIGHTBLUE_PRIVATE_KEY = "./lb-freshmaker-key.pem"
     LIGHTBLUE_RELEASED_DEPENDENCIES_ONLY = True
 
+    PYXIS_SERVER_URL = 'https://pyxis.localhost.tld/'
+    PYXIS_INDEX_IMAGE_ORGANIZATION = 'organization'
+
     HANDLER_BUILD_WHITELIST = {
         'global': {
             'image': any_(

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -91,9 +91,7 @@ def init_config(app):
     # In any of the following cases, use configuration directly from Freshmaker
     # package -> /conf/config.py.
 
-    elif ('FRESHMAKER_DEVELOPER_ENV' in os.environ and
-          'FRESHMAKER_CONFIG_FILE' not in os.environ and
-          os.environ['FRESHMAKER_DEVELOPER_ENV'].lower() in ('1', 'on', 'true', 'y', 'yes')):
+    elif os.environ.get('FRESHMAKER_DEVELOPER_ENV', '').lower() in ('1', 'on', 'true', 'y', 'yes'):
         config_section = 'DevConfiguration'
         if 'FRESHMAKER_CONFIG_FILE' in os.environ:
             config_file = os.environ['FRESHMAKER_CONFIG_FILE']
@@ -401,6 +399,16 @@ class Config(object):
             'type': str,
             'default': 'all',
             'desc': 'vcr mode for recording lightblue queries'
+        },
+        'pyxis_server_url': {
+            'type': str,
+            'default': '',
+            'desc': 'Server URL of Pyxis.'
+        },
+        'pyxis_index_image_organization': {
+            'type': str,
+            'default': '',
+            'desc': 'Query Pyxis for index images only with this organization'
         }
     }
 

--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -19,11 +19,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from freshmaker import db
+from freshmaker import db, conf, log
 from freshmaker.handlers import ContainerBuildHandler
 from freshmaker.events import BotasErrataShippedEvent
 from freshmaker.models import Event
 from freshmaker.types import EventState
+from freshmaker.pyxis import Pyxis
+from freshmaker.kojiservice import koji_service
 
 
 class HandleBotasAdvisory(ContainerBuildHandler):
@@ -32,6 +34,15 @@ class HandleBotasAdvisory(ContainerBuildHandler):
     BOTAS to SHIPPED_LIVE state
     """
     name = "HandleBotasAdvisory"
+
+    def __init__(self, pyxis=None):
+        super().__init__()
+        if pyxis:
+            self._pyxis = pyxis
+        else:
+            if not conf.pyxis_server_url:
+                raise ValueError("'pyxis_server_url' parameter should be set")
+            self._pyxis = Pyxis(conf.pyxis_server_url)
 
     def can_handle(self, event):
         if (isinstance(event, BotasErrataShippedEvent) and
@@ -56,7 +67,6 @@ class HandleBotasAdvisory(ContainerBuildHandler):
             msg = ("This image rebuild is not allowed by internal policy. "
                    f"message_id: {event.msg_id}")
             db_event.transition(EventState.SKIPPED, msg)
-            db.session.commit()
             self.log_info(msg)
             return []
 
@@ -65,12 +75,75 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         self.log_info(
             "Orignial nvrs of build in the advisory #{0} are: {1}".format(
                 db_event.search_key, " ".join(original_nvrs)))
+        # Get images by nvrs and then get their digests
+        original_images_digests = set(self._pyxis.get_digests_by_nvrs(original_nvrs))
+        if not original_images_digests:
+            msg = f"The are no digests for NVRs: {','.join(original_nvrs)}"
+            log.warning(msg)
+            db_event.transition(EventState.SKIPPED, msg)
+            db.session.commit()
+            return []
 
-        msg = "Skipping due to being blocked on further implementation for now."
+        index_images = self._pyxis.get_operator_indices()
+        # get latest bundle images per channel per index image filtered
+        # by the highest semantic version
+        all_bundles = self._pyxis.get_latest_bundles(index_images)
+
+        bundles = self._pyxis.filter_bundles_by_related_image_digests(
+            original_images_digests, all_bundles)
+        bundle_digests = set()
+        for bundle in bundles:
+            if not bundle.get('bundle_path_digest'):
+                log.warning("Bundle %s doesn't have 'bundle_path_digests' set",
+                            bundle['bundle_path'])
+                continue
+            bundle_digests.add(bundle['bundle_path_digest'])
+        bundle_images = self._pyxis.get_images_by_digests(bundle_digests)
+
+        # get NVRs only of those bundles, which have OSBS pinning
+        bundles_nvrs = self._filter_bundles_by_pinned_related_images(
+            bundle_images)
 
         # Skip that event because we can't proceed with processing it.
         # TODO
-        # Next step would be queries Pyxis and getting the digests of these nvrs
+        # Now when we have bundle images' nvrs we can procceed with rebuilding it
+        msg = f"Skipping the rebuild of {len(bundles_nvrs)} bundle images " \
+              "due to being blocked on further implementation for now."
         db_event.transition(EventState.SKIPPED, msg)
-        db.session.commit()
         return []
+
+    def _filter_bundles_by_pinned_related_images(self, bundle_images):
+        """
+        If the digests were not pinned by OSBS, the bundle image
+        will be filtered out.
+
+        There is no need in checking pinning for every of related images,
+        because we already know that digest points to the manifest list,
+        because of previous filtering.
+
+        :param list bundle_images: ContainerImages of operator bundles
+        :return: list of NVRs of bundle images that have at least one
+            original related image that was rebuilt
+        """
+        ret_bundle_images_nvrs = set()
+        with koji_service(conf.koji_profile, log, dry_run=self.dry_run,
+                          login=False) as session:
+            for bundle in bundle_images:
+                nvr = bundle['brew']['build']
+                build = session.get_build(nvr)
+                if not build:
+                    log.error("Could not find the build %s in Koji", nvr)
+                    continue
+                related_images = (
+                    build.get("build", {})
+                         .get("extra", {})
+                         .get("image", {})
+                         .get("operator_manifests", {})
+                         .get("related_images", {})
+                )
+
+                # Skip the bundle if the related images section was not populated by OSBS
+                if related_images.get("created_by_osbs") is not True:
+                    continue
+                ret_bundle_images_nvrs.add(nvr)
+        return ret_bundle_images_nvrs

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -1,0 +1,220 @@
+import requests
+import urllib
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+from packaging import version
+
+from freshmaker import log, conf
+
+
+class PyxisRequestError(Exception):
+    """
+    Error return as a response from Pyxis
+    """
+
+    def __init__(self, status_code, error_response):
+        """
+        Initialize Pyxis request error
+
+        :param int status_code: response status code
+        :param str or dict error_response: response content returned from Pyxis
+        """
+
+        self._status_code = status_code
+        self._raw = error_response
+
+    @property
+    def raw(self):
+        return self._raw
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+
+class Pyxis(object):
+    """ Interface for querying Pyxis"""
+
+    def __init__(self, server_url):
+        self._server_url = server_url
+        # add api version to root url
+        self._api_root = urllib.parse.urljoin(self._server_url, "v1/")
+
+    def _make_request(self, entity, params):
+        """
+        Send a request to Pyxis
+
+        :param str entity: entity part to construct a full URL for request.
+        :param dict params: Pyxis query parameters.
+        :return: Json response from Pyxis
+        :rtype: dict
+        :raises PyxisRequestError: If Pyxis returns error as a response
+        """
+        entity_url = urllib.parse.urljoin(self._api_root, entity)
+
+        auth_method = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        response = requests.get(entity_url, params=params, auth=auth_method,
+                                timeout=conf.net_timeout)
+
+        if response.ok:
+            return response.json()
+
+        # Warn early, in case there is an error in the error handling code below
+        log.warning("Request to %s gave %r", response.request.url, response)
+
+        try:
+            response_text = response.json()
+        except ValueError:
+            response_text = response.text
+
+        raise PyxisRequestError(response.status_code, response_text)
+
+    def _pagination(self, entity, params):
+        """
+        Process all pages in Pyxis
+
+        :param str entity: what data/entity to request from Pyxis
+        :param dict params: parameters to add to GET request
+        :return: list of all 'data' fields from responses from Pyxis
+        :rtype: list
+        """
+        local_params = {"page_size": "100"}
+        local_params.update(params)
+        ret = []
+        page = 0
+        while True:
+            local_params["page"] = page
+            response_data = self._make_request(entity, params=local_params)
+            # When the page after the actual last page is reached, data will be an empty list
+            if not response_data.get('data'):
+                break
+            ret.extend(response_data['data'])
+            page += 1
+
+        return ret
+
+    def get_operator_indices(self):
+        """ Get all index images for organization(s)(configurable) from Pyxis """
+        request_params = {}
+        organization = conf.pyxis_index_image_organization
+        if organization:
+            request_params["filter"] = "organization==" + organization
+
+        return self._pagination("operators/indices", request_params)
+
+    def _get_bundles_per_index_image(self, index_images):
+        """
+        Get bundle images for all index images
+
+        :param list index_images: list of index images to get bundle images for
+        :return: bundle images per index image
+        :rtype: dict
+        """
+        bundles_per_index_image = {}
+        # we need 'bundle_path_digest' to find ContainerImage of that bundle
+        include_fields = ['data.channel_name', 'data.version',
+                          'data.related_images', 'data.bundle_path_digest',
+                          'data.bundle_path']
+        request_params = {'include': ','.join(include_fields)}
+        for index_image in index_images:
+            path = index_image.get('path', '')
+            if not path:
+                continue
+            request_params['filter'] = f"source_index_container_path=={path}"
+            bundles_per_index_image[path] = self._pagination(
+                'operators/bundles',
+                request_params)
+
+        return bundles_per_index_image
+
+    def get_latest_bundles(self, index_images):
+        """
+        Get latest bundle images per channel per index image
+
+        :param list index_images: list of index images
+        :return: latest bundle images per channel per index image
+        :rtype: list
+        """
+        bundles_per_index_image = \
+            self._get_bundles_per_index_image(index_images)
+
+        ret_bundles = []
+        for index_image, bundles in bundles_per_index_image.items():
+            bundle_per_channel = {}
+            # get latest versions of bundle images per channel
+            for bundle in bundles:
+                channel = bundle['channel_name']
+                try:
+                    # Always ensure the new version is a valid semantic version
+                    new_ver = version.Version(bundle['version'])
+                    if channel in bundle_per_channel:
+                        old_ver = version.Version(
+                            bundle_per_channel[channel]['version'])
+                        if new_ver > old_ver:
+                            bundle_per_channel[channel] = bundle
+                    else:
+                        bundle_per_channel[channel] = bundle
+                # Check if the right format of version is used
+                except version.InvalidVersion as e:
+                    path = bundle.get('bundle_path', 'Unknown bundle path')
+                    log.warning("Other format than SemVer is used in "
+                                "bundle: %s", path)
+                    log.warning(repr(e))
+            ret_bundles.extend(bundle_per_channel.values())
+
+        return ret_bundles
+
+    def get_digests_by_nvrs(self, nvrs):
+        """
+        Get images' digests(manifest_list_digest field) by their NVRs
+
+        :param list nvrs: list of NVRs of ContainerImages to query Pyxis
+        :return: digests of images which we get by NVRs
+        :rtype: set
+        """
+        request_params = {'include': ','.join(['data.brew', 'data.repositories'])}
+
+        # get all manifest_list_digest of ContainerImages we got from Pyxis
+        digests = set()
+        for nvr in nvrs:
+            for image in self._pagination(f'images/nvr/{nvr}', request_params):
+                for repo in image.get('repositories'):
+                    if repo['published'] and 'manifest_list_digest' in repo:
+                        digests.add(repo['manifest_list_digest'])
+                        break
+        return digests
+
+    def filter_bundles_by_related_image_digests(self, original_digests,
+                                                bundles):
+        """
+        Filter out bundles that don't have at least one 'related_image'
+        with the same manifest list digest as those in 'original_digests'
+
+        :param set original_digests: digests of the original
+            operator/operand (related image) images to filter bundles by them
+        :param list bundles: bundles to filter
+        :return: filtered list of bundles
+        :rtype: list
+        """
+        ret_bundles = []
+        # If bundle doesn't have any of digests of images, don't add it to return list
+        for bundle in bundles:
+            for image in bundle.get('related_images', []):
+                # If same digest within images' digests is found, it will be in return list
+                if image.get('digest') in original_digests:
+                    ret_bundles.append(bundle)
+                    break
+
+        return ret_bundles
+
+    def get_images_by_digests(self, digests):
+        """
+        Get bundle ContainerImages by the digests in their
+        'repositories.*.manifest_list_digest'
+
+        :param set digests: digests for Pyxis filter inside query
+        :return: bundle ContainerImages
+        :rtype: list
+        """
+        request_params = {'include': 'data.brew',
+                          'filter': f"repositories.manifest_list_digest=in=({','.join(digests)})"}
+        return self._pagination("images", request_params)

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -19,12 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from unittest.mock import patch, call, MagicMock
+
+from freshmaker import db, conf
 from freshmaker.events import (
     BotasErrataShippedEvent,
-    ManualRebuildWithAdvisoryEvent,
-    ErrataAdvisoryRPMsSignedEvent)
+    ManualRebuildWithAdvisoryEvent)
 from freshmaker.handlers.botas import HandleBotasAdvisory
 from freshmaker.errata import ErrataAdvisory
+from freshmaker.models import Event
+from freshmaker.types import EventState
 from tests import helpers
 
 
@@ -38,27 +42,183 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         # tests.
         self.patcher = helpers.Patcher(
             'freshmaker.handlers.botas.botas_shipped_advisory.')
+        self.pyxis = self.patcher.patch("Pyxis")
 
         # We do not want to send messages to message bus while running tests
         self.mock_messaging_publish = self.patcher.patch(
             'freshmaker.messaging.publish')
 
+        self.handler = HandleBotasAdvisory()
+
         self.botas_advisory = ErrataAdvisory(
             123, "RHBA-2020", "SHIPPED_LIVE", ['docker'])
         self.botas_advisory._reporter = "botas/pnt-devops-jenkins@REDHAT.COM"
-        self.rhba_event = ErrataAdvisoryRPMsSignedEvent(
-            "123", self.botas_advisory)
 
     def tearDown(self):
         super(TestBotasShippedAdvisory, self).tearDown()
         self.patcher.unpatch_all()
 
+    @patch.object(conf, 'pyxis_server_url', new='test_url')
+    def test_init(self):
+        handler1 = HandleBotasAdvisory(self.pyxis)
+        self.assertEqual(handler1._pyxis, self.pyxis)
+
+        HandleBotasAdvisory()
+        self.pyxis.assert_called_with('test_url')
+
+    @patch.object(conf, 'pyxis_server_url', new='')
+    def test_init_no_pyxis_server(self):
+        with self.assertRaises(ValueError, msg="'pyxis_server_url' parameter should be set"):
+            HandleBotasAdvisory()
+
     def test_can_handle_botas_adisory(self):
-        event = BotasErrataShippedEvent("123", self.botas_advisory)
         handler = HandleBotasAdvisory()
+        event = BotasErrataShippedEvent("123", self.botas_advisory)
         self.assertTrue(handler.can_handle(event))
+
+    def test_handle_set_dry_run(self):
+        event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory,
+                                        dry_run=True)
+        self.handler.handle(event)
+
+        self.assertTrue(self.handler._force_dry_run)
+        self.assertTrue(self.handler.dry_run)
+
+    def test_handle_isnt_allowed_by_internal_policy(self):
+        event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
+
+        self.handler.handle(event)
+        db_event = Event.get(db.session, message_id='test_msg_id')
+
+        self.assertEqual(db_event.state, EventState.SKIPPED.value)
+        self.assertTrue(db_event.state_reason.startswith(
+            "This image rebuild is not allowed by internal policy."))
+
+    @patch.object(conf, 'dry_run', new=True)
+    @patch.object(conf, 'handler_build_whitelist', new={
+        'HandleBotasAdvisory': {
+            'image': {
+                'advisory_name': 'RHBA-2020'
+            }
+        }})
+    def test_handle_no_digests_error(self):
+        event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
+        self.pyxis().get_digests_by_nvrs.return_value = set()
+
+        self.handler.handle(event)
+        db_event = Event.get(db.session, message_id='test_msg_id')
+
+        self.assertEqual(db_event.state, EventState.SKIPPED.value)
+        self.assertTrue(
+            db_event.state_reason.startswith("The are no digests for NVRs:"))
+
+    @patch.object(conf, 'dry_run', new=True)
+    @patch.object(conf, 'handler_build_whitelist', new={
+        'HandleBotasAdvisory': {
+            'image': {
+                'advisory_name': 'RHBA-2020'
+            }
+        }})
+    def test_handle_get_bundle_paths(self):
+        event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
+        self.pyxis().get_digests_by_nvrs.return_value = {'nvr1'}
+        bundles = [
+            {
+                "bundle_path": "some_path",
+                "bundle_path_digest": "sha256:123123",
+                "channel_name": "streams-1.5.x",
+                "related_images": [
+                    {
+                        "image": "registry/amq7/amq-streams-r-operator@sha256:111",
+                        "name": "strimzi-cluster-operator",
+                        "digest": "sha256:111"
+                    },
+                ],
+                "version": "1.5.3"
+            },
+            {
+                "bundle_path": "some_path_2",
+                "channel_name": "streams-1.5.x",
+                "related_images": [
+                    {
+                        "image": "registry/amq7/amq-streams-r-operator@sha256:555",
+                        "name": "strimzi-cluster-operator",
+                        "digest": "sha256:555"
+                    },
+                ],
+                "version": "1.5.4"
+            },
+        ]
+        self.pyxis().filter_bundles_by_related_image_digests.return_value = bundles
+
+        self.handler.handle(event)
+        db_event = Event.get(db.session, message_id='test_msg_id')
+
+        # should be called only with the first digest, because second one
+        # doesn't have 'bundle_path_digest'
+        self.pyxis().get_images_by_digests.assert_called_once_with({"sha256:123123"})
+        self.assertEqual(db_event.state, EventState.SKIPPED.value)
+        self.assertTrue(
+            db_event.state_reason.startswith("Skipping the rebuild of"))
 
     def test_can_handle_manual_rebuild_with_advisory(self):
         event = ManualRebuildWithAdvisoryEvent("123", self.botas_advisory, [])
-        handler = HandleBotasAdvisory()
-        self.assertFalse(handler.can_handle(event))
+        self.assertFalse(self.handler.can_handle(event))
+
+    @patch('freshmaker.handlers.botas.botas_shipped_advisory.koji_service')
+    def test_filter_bundles_by_pinned_related_images(self, service):
+        bundle_images = [
+            {
+                "brew": {
+                    "build": "some_nvr_1"
+                }
+            },
+            {
+                "brew": {
+                    "build": "some_nvr_2"
+                }
+            },
+            {
+                "brew": {
+                    "build": "some_nvr_3"
+                }
+            }
+        ]
+        temp_mock = MagicMock()
+        service.return_value.__enter__.return_value = temp_mock
+        temp_mock.get_build.side_effect = [
+            {
+                "build": {
+                    "extra": {
+                        "image": {
+                            "operator_manifests": {
+                                "related_images": {
+                                    "created_by_osbs": True
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "build": {
+                    "extra": {
+                        "image": {
+                            "operator_manifests": {
+                                "related_images": {
+                                    "created_by_osbs": False
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            # To check that we will ignore invalid/not found build
+            None
+        ]
+
+        nvrs = self.handler._filter_bundles_by_pinned_related_images(bundle_images)
+
+        temp_mock.get_build.assert_has_calls([call("some_nvr_1"),
+                                             call("some_nvr_2")])
+        self.assertEqual(nvrs, {"some_nvr_1"})

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -1,0 +1,433 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020  Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import requests
+
+from http import HTTPStatus
+from copy import deepcopy
+from unittest.mock import call, patch, create_autospec, Mock
+
+from freshmaker import conf
+from freshmaker.pyxis import Pyxis, PyxisRequestError
+
+from tests import helpers
+
+
+class TestQueryPyxis(helpers.FreshmakerTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.patcher = helpers.Patcher(
+            'freshmaker.pyxis.')
+
+        self.fake_server_url = 'https://pyxis.localhost/'
+        self.px = Pyxis(self.fake_server_url)
+        self.response = create_autospec(requests.Response)
+        self.response.status_code = HTTPStatus.OK
+        self.bad_requests_response = {
+            "detail": [
+                "Unable to parse the filter from URL.",
+                "Please verify the 'Field Name' in the RSQL Expression.",
+                "Please visit the following end-point for more details:",
+                "    /v1/docs/filtering-language"
+            ],
+            "status": 400,
+            "title": "Bad Request",
+            "type": "about:blank"
+        }
+
+        self.empty_response_page = {
+            "data": [],
+            "page": 0,
+            "page_size": 100,
+            "total": 0
+        }
+
+        self.indices = [
+            {
+                "_id": "1",
+                "created_by": "meteor",
+                "creation_date": "2020-01-01T09:32:31.692000+00:00",
+                "last_update_date": "2020-01-01T09:32:31.692000+00:00",
+                "last_updated_by": "meteor",
+                "ocp_version": "4.5",
+                "organization": "org",
+                "path": "path/to/registry:v4.5"
+            },
+            {
+                "_id": "2",
+                "created_by": "meteor",
+                "creation_date": "2020-01-01T09:32:38.486000+00:00",
+                "last_update_date": "2020-01-01T09:32:38.486000+00:00",
+                "last_updated_by": "meteor",
+                "ocp_version": "4.6",
+                "organization": "org",
+                "path": "path/to/registry:v4.6"
+            },
+            {
+                "_id": "2",
+                "created_by": "meteor",
+                "creation_date": "2020-01-01T09:32:38.486000+00:00",
+                "last_update_date": "2020-01-01T09:32:38.486000+00:00",
+                "last_updated_by": "meteor",
+                "ocp_version": "4.6",
+                "organization": "org",
+                "path": ""
+            }
+        ]
+
+        self.bundles = [
+            {
+                "channel_name": "streams-1.5.x",
+                "related_images": [
+                    {
+                        "image": "registry/amq7/amq-streams-r-operator@sha256:111",
+                        "name": "strimzi-cluster-operator",
+                        "digest": "sha256:111"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-kafka-24-r@sha256:222",
+                        "name": "strimzi-kafka-24",
+                        "digest": "sha256:222"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-kafka-25-r@sha256:333",
+                        "name": "strimzi-kafka-25",
+                        "digest": "sha256:333"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-bridge-r@sha256:444",
+                        "name": "strimzi-bridge",
+                        "digest": "sha256:444"
+                    }
+                ],
+                "version": "1.5.3"
+            },
+            {
+                "channel_name": "streams-1.5.x",
+                "related_images": [
+                    {
+                        "image": "registry/amq7/amq-streams-r-operator@sha256:555",
+                        "name": "strimzi-cluster-operator",
+                        "digest": "sha256:555"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-kafka-24-r@sha256:666",
+                        "name": "strimzi-kafka-24",
+                        "digest": "sha256:666"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-kafka-25-r@sha256:777",
+                        "name": "strimzi-kafka-25",
+                        "digest": "sha256:777"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-bridge-r@sha256:888",
+                        "name": "strimzi-bridge",
+                        "digest": "sha256:888"
+                    }
+                ],
+                "version": "1.5.4"
+            },
+            {
+                "channel_name": "stable",
+                "related_images": [
+                    {
+                        "image": "registry/amq7/amq--operator@sha256:999",
+                        "name": "strimzi-cluster-operator",
+                        "digest": "sha256:999"
+                    },
+                    {
+                        "image": "registry/amq7/kafka-24-r@sha256:aaa",
+                        "name": "strimzi-kafka-24",
+                        "digest": "sha256:aaa"
+                    },
+                    {
+                        "image": "registry/amq7/kafka-25-r@sha256:bbb",
+                        "name": "strimzi-kafka-25",
+                        "digest": "sha256:bbb"
+                    },
+                    {
+                        "image": "registry/amq7/amq-streams-bridge-r@sha256:ccc",
+                        "name": "strimzi-bridge",
+                        "digest": "sha256:ccc"
+                    }
+                ],
+                "version": "1.5.3"
+            },
+            {
+                "channel_name": "stable",
+                "related_images": [
+                    {
+                        "image": "registry/tracing/j-operator:1.13.2",
+                        "name": "j-1.13.2-annotation",
+                        "digest": "sha256:fff"
+                    },
+                    {
+                        "image": "registry/tracing/j-operator:1.13.2",
+                        "name": "j-operator",
+                        "digest": "sha256:ffff"
+                    }
+                ],
+                "version": "1.5.2"
+            },
+            {
+                "channel_name": "quay-v3.3",
+                "related_images": [
+                    {
+                        "image": "registry/quay/quay-operator@sha256:ddd",
+                        "name": "quay-operator-annotation",
+                        "digest": "sha256:ddd"
+                    },
+                    {
+                        "image": "registry/quay/quay-security-r-operator@sha256:eee",
+                        "name": "container-security-operator",
+                        "digest": "sha256:eee"
+                    }
+                ],
+                "version": "3.3.1"
+            },
+        ]
+
+        self.images = [
+            {
+                "brew": {
+                    "build": "s2i-1-2",
+                    "completion_date": "2020-08-12T11:31:39+00:00",
+                    "nvra": "s2i-1-2.ppc64le",
+                    "package": "s2i-core-container"
+                },
+                "repositories": [
+                    {
+                        "manifest_list_digest": "sha256:1111",
+                        "published": False
+                    },
+                    {
+                        "manifest_list_digest": "sha256:1112",
+                        "published": True
+                    }
+                ]
+            },
+            {
+                "brew": {
+                    "build": "s2i-1-2",
+                    "completion_date": "2020-08-12T11:31:39+00:00",
+                    "nvra": "s2i-1-2.s390x",
+                    "package": "s2i-core-container"
+                },
+                "repositories": [
+                    {
+                        "manifest_list_digest": "sha256:2222",
+                        "published": True
+                    }
+                ]
+            },
+            {
+                "brew": {
+                    "build": "s2i-1-2",
+                    "completion_date": "2020-08-12T11:31:39+00:00",
+                    "nvra": "s2i-1-2.amd64",
+                    "package": "s2i-core-container"
+                },
+                "repositories": [
+                    {
+                        "manifest_list_digest": "sha256:3333",
+                        "published": True
+                    }
+                ]
+            },
+            {
+                "brew": {
+                    "build": "s2i-1-2",
+                    "completion_date": "2020-08-12T11:31:39+00:00",
+                    "nvra": "s2i-1-2.arm64",
+                    "package": "s2i-core-container"
+                },
+                "repositories": [
+                    {
+                        "manifest_list_digest": "sha256:4444",
+                        "published": True
+                    }
+                ]
+            }
+        ]
+
+    def tearDown(self):
+        super().tearDown()
+        self.patcher.unpatch_all()
+
+    @staticmethod
+    def copy_call_args(mock):
+        """
+        Copy args of Mock to another Mock so we can check call args if we call
+        mock with mutable args and change it between calls
+        """
+        new_mock = Mock()
+
+        def side_effect(*args, **kwargs):
+            args = deepcopy(args)
+            kwargs = deepcopy(kwargs)
+            return new_mock(*args, **kwargs)
+        mock.side_effect = side_effect
+        return new_mock
+
+    @patch('freshmaker.pyxis.HTTPKerberosAuth')
+    @patch('freshmaker.pyxis.requests.get')
+    def test_make_request(self, get, auth):
+        get.return_value = self.response
+        test_params = {'key1': 'val1'}
+        self.px._make_request('test', test_params)
+
+        get_url = self.fake_server_url + 'v1/test'
+        self.response.json.assert_called_once()
+        test_params['page_size'] = "100"
+        get.assert_called_once_with(get_url, params=test_params, auth=auth(),
+                                    timeout=conf.net_timeout)
+
+    @patch('freshmaker.pyxis.HTTPKerberosAuth')
+    @patch('freshmaker.pyxis.requests.get')
+    def test_make_request_error(self, get, auth):
+        get.return_value = self.response
+        self.response.ok = False
+        self.response.json.side_effect = ValueError
+        self.response.json.text = 'test message'
+        self.response.request = Mock()
+        self.response.request.url = 'test/url'
+
+        with self.assertRaises(PyxisRequestError, msg='test message'):
+            self.px._make_request('test', {})
+
+    @patch('freshmaker.pyxis.HTTPKerberosAuth')
+    @patch('freshmaker.pyxis.Pyxis._make_request')
+    def test_pagination(self, request, auth):
+        my_request = self.copy_call_args(request)
+        my_request.side_effect = [
+            {"page": 0, "data": ["fake_data1"]},
+            {"page": 1, "data": ["fake_data2"]},
+            {"page": 2, "data": []}
+        ]
+        test_params = {'include': ['total', 'field1']}
+        entity = 'test'
+        auth.return_value = 1
+        self.px._pagination(entity, test_params)
+
+        self.assertEqual(request.call_count, 3)
+        default_params = {'page_size': '100', 'include': ['total', 'field1']}
+        calls = [call('test', params={**default_params, 'page': 0}),
+                 call('test', params={**default_params, 'page': 1}),
+                 call('test', params={**default_params, 'page': 2})
+                 ]
+        my_request.assert_has_calls(calls)
+
+    @patch.object(conf, 'pyxis_index_image_organization', new='org')
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_operator_indices(self, page):
+        self.px.get_operator_indices()
+        page.assert_called_once_with(
+            'operators/indices', {'filter': 'organization==org'})
+
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_bundles_per_index_image(self, page):
+        page_copy = self.copy_call_args(page)
+        page_copy.side_effect = [self.bundles[0:2], self.bundles[2:]]
+        out = self.px._get_bundles_per_index_image(self.indices)
+
+        expected_out = {"path/to/registry:v4.5": self.bundles[0:2],
+                        "path/to/registry:v4.6": self.bundles[2:]}
+
+        self.assertEqual(out, expected_out)
+        page.assert_has_calls([
+            call('operators/bundles',
+                 {'include': 'data.channel_name,data.version,'
+                             'data.related_images,data.bundle_path_digest,'
+                             'data.bundle_path', 'filter':
+                     'source_index_container_path==path/to/registry:v4.6'}),
+            call('operators/bundles',
+                 {'include': 'data.channel_name,data.version,'
+                             'data.related_images,data.bundle_path_digest,'
+                             'data.bundle_path', 'filter':
+                     'source_index_container_path==path/to/registry:v4.6'})
+        ])
+
+    @patch('freshmaker.pyxis.Pyxis._get_bundles_per_index_image')
+    def test_get_latest_bundles(self, get_bundles_per_indices):
+        get_bundles_per_indices.return_value = {
+            "path/to/registry:v4.5": self.bundles[0:2],
+            "path/to/registry:v4.6": self.bundles[2:]
+        }
+
+        out = self.px.get_latest_bundles(self.indices)
+        # we expect 0 and 3 bundles to be filtered out, because of older versions
+        expected_out = self.bundles[1:3] + self.bundles[4:]
+        self.assertEqual(out, expected_out)
+        get_bundles_per_indices.assert_called_once()
+
+    @patch('freshmaker.pyxis.Pyxis._get_bundles_per_index_image')
+    def test_get_latest_bundles_invalid_version(self, get_bundles_per_indices):
+        # set invalid version
+        for bundle in self.bundles:
+            bundle['version'] = "InvalidVersion"
+        get_bundles_per_indices.return_value = {
+            "path/to/registry:v4.5": self.bundles[0:2],
+            "path/to/registry:v4.6": self.bundles[2:]
+        }
+
+        with self.assertLogs("freshmaker", level="WARNING"):
+            bundles = self.px.get_latest_bundles(self.indices)
+            self.assertEqual(bundles, [])
+            get_bundles_per_indices.assert_called_once()
+
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_digests_by_nvrs(self, page):
+        page.return_value = self.images
+        digests = self.px.get_digests_by_nvrs(['s2i-1-2'])
+
+        expected_digests = {'sha256:1112', 'sha256:4444', 'sha256:3333',
+                            'sha256:2222'}
+        self.assertEqual(digests, expected_digests)
+        page.assert_called_once_with(
+            'images/nvr/s2i-1-2',
+            {'include': 'data.brew,data.repositories'}
+        )
+
+    def test_filter_bundles_by_related_image_digests(self):
+        digests = {'sha256:111', 'sha256:bbb', 'sha256:ddd'}
+        new_bundles = self.px.filter_bundles_by_related_image_digests(
+            digests, self.bundles)
+
+        expected_bundles = [self.bundles[0], self.bundles[2], self.bundles[4]]
+        self.assertListEqual(new_bundles, expected_bundles)
+
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_images_by_digests(self, page):
+        my_pagination = self.copy_call_args(page)
+        my_pagination.return_value = [self.images[0], self.images[1]]
+        images = self.px.get_images_by_digests(['sha256:111', 'sha256:222'])
+
+        my_pagination.assert_called_once_with(
+            'images', {'include': 'data.brew',
+                       'filter': 'repositories.manifest_list_digest=in='
+                                 '(sha256:111,sha256:222)'
+                       }
+        )
+        self.assertEqual(page.call_count, 1)
+        self.assertEqual(self.images[0:2], images)


### PR DESCRIPTION
New Pyxis module to query bundle images and ContainerImages by thier
nvrs. So we can find bundle images for the operator/operand images that
were rebuilt by us previously.

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>