### PR TITLE
Exclude operator indices that haven't been released

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -409,6 +409,11 @@ class Config(object):
             'type': str,
             'default': '',
             'desc': 'Query Pyxis for index images only with this organization'
+        },
+        'product_pages_api_url': {
+            'type': str,
+            'default': '',
+            'desc': 'The API URL of the Product Pages service'
         }
     }
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,11 @@
 -r requirements.txt
 
 copr
+freezegun
 pytest
 pytest-cov
 vcrpy
+requests_mock
 tox
 mypy
 # It seems like Flask needs this itsdangerous package.


### PR DESCRIPTION
Operator index can exists in Pyxis even the product has not been
released, these indices should be excluded. By checking Product
Page, we can get release date of an OpenShift version, and then
can compare the release date with current date to know whether
the product is released.

JIRA: CLOUDWF-4084