### PR TITLE
Migrate to koji gssapi_login API

### DIFF
--- a/freshmaker/kojiservice.py
+++ b/freshmaker/kojiservice.py
@@ -92,9 +92,11 @@ class KojiService(object):
     def krb_login(self):
         # No need to login on dry run, this makes dry run much faster.
         if not self.dry_run:
-            self.session.krb_login(principal=conf.krb_auth_principal,
-                                   keytab=conf.krb_auth_client_keytab,
-                                   ccache=conf.krb_auth_ccache_file)
+            self.session.gssapi_login(
+                principal=conf.krb_auth_principal,
+                keytab=conf.krb_auth_client_keytab,
+                ccache=conf.krb_auth_ccache_file
+            )
         else:
             log.info("DRY RUN: Skipping login in dry run mode.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Flask-Migrate
 Flask-SQLAlchemy
 Flask-Login
 requests
+requests-kerberos
 odcs[client]
 dogpile.cache
 pyldap

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -31,6 +31,7 @@ python3-pyOpenSSL
 python3-pyyaml
 python3-qpid-proton
 python3-requests
+python3-requests-kerberos
 python3-rpm
 python3-setuptools
 python3-sqlalchemy


### PR DESCRIPTION
Use koji's gssapi_login API instead of krb_login

krb_login() is deprecated, and for ClientSession objects, krb_login()
is currently redirected to gssapi_login() with a printed warning.

More details:
https://docs.pagure.org/koji/migrations/migrating_to_1.22/#migration-krbv

And add python requests-kerberos package explicitly in yum-packages.txt
and requirements.txt.