### PR TITLE
Get original nvrs from incoming message

### DIFF
--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -57,6 +57,7 @@ class ErrataAdvisory(object):
 
         self._affected_rpm_nvrs = None
         self._reporter = ""
+        self._builds = None
 
     @property
     def affected_rpm_nvrs(self):
@@ -76,6 +77,15 @@ class ErrataAdvisory(object):
         advisory_data = errata._get_advisory_legacy(self.errata_id)
         self._reporter = advisory_data['people']['reporter']
         return self._reporter
+
+    @property
+    def builds(self):
+        if self._builds is None:
+            errata = Errata()
+            self._builds = errata._errata_rest_get(f"erratum/{self.errata_id}"
+                                                   "/builds")
+
+        return self._builds
 
     @classmethod
     def from_advisory_id(cls, errata, errata_id):

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -194,7 +194,7 @@ class Pyxis(object):
         """
         Get images' digests(manifest_list_digest field) by their NVRs
 
-        :param list nvrs: list of NVRs of ContainerImages to query Pyxis
+        :param set nvrs: set of NVRs of ContainerImages to query Pyxis
         :return: digests of images which we get by NVRs
         :rtype: set
         """


### PR DESCRIPTION
Fix bug when original nvrs were extracted from new event instead of
searching for advisory builds and then searching Freshmaker db for older
build events.

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>