### PR TITLE
Add pullspec overrides data for related images in each bundle image

### DIFF
--- a/freshmaker/migrations/versions/fcba8824bf8d_add_bundle_pullspec_overrides.py
+++ b/freshmaker/migrations/versions/fcba8824bf8d_add_bundle_pullspec_overrides.py
@@ -1,0 +1,22 @@
+"""Add bundle_pullspec_overrides to artifact_builds
+
+Revision ID: fcba8824bf8d
+Revises: 2358b6f55f24
+Create Date: 2021-01-11 21:36:49.189627
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fcba8824bf8d'
+down_revision = '2358b6f55f24'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('artifact_builds', sa.Column('bundle_pullspec_overrides', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('artifact_builds', 'bundle_pullspec_overrides')

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -559,6 +559,11 @@ class ArtifactBuild(FreshmakerBase):
     # `freshmaker.types.RebuildReason`.
     rebuild_reason = db.Column(db.Integer, nullable=True)
 
+    # pullspec overrides
+    _bundle_pullspec_overrides = db.Column(
+        "bundle_pullspec_overrides", db.Text, nullable=True
+    )
+
     composes = db.relationship('ArtifactBuildCompose', back_populates='build')
 
     @classmethod
@@ -616,6 +621,28 @@ class ArtifactBuild(FreshmakerBase):
         if not build:
             return 0
         return build.build_id
+
+    @property
+    def bundle_pullspec_overrides(self):
+        """Return the Python representation of the JSON bundle_pullspec_overrides."""
+        return (
+            json.loads(self._bundle_pullspec_overrides)
+            if self._bundle_pullspec_overrides
+            else None
+        )
+
+    @bundle_pullspec_overrides.setter
+    def bundle_pullspec_overrides(self, bundle_pullspec_overrides):
+        """
+        Set the bundle_pullspec_overrides column to the input bundle_pullspec_overrides as a JSON string.
+        If ``None`` is provided, it will be simply set to ``None`` and not be converted to JSON.
+        :param dict bundle_pullspec_overrides: the dictionary of the bundle_pullspec_overrides or ``None``
+        """
+        self._bundle_pullspec_overrides = (
+            json.dumps(bundle_pullspec_overrides, sort_keys=True)
+            if bundle_pullspec_overrides is not None
+            else None
+        )
 
     def depending_artifact_builds(self):
         """


### PR DESCRIPTION
For each bundle image we're going to rebuild when operator/operand
images are shipped, pullspec overrides data is required, the general
workflow is: 

1. Get the current image NVRs in advisory, these are rebuilt images
2. Get the original image NVRs for rebuilt images
3. Get digests of original images
4. Get digests of rebuilt images
5. With digests of original images, we can search in all latest bundle
   images to get the bundles which have original images are connected.
6. For each bundle image, if this image is not enabled for rebuild, skip
   it.
7. For each bundle image, if a related image is in original digests (step
   3), and osbs-pinning is used, update the digest with digest of rebuilt
   image.

JIRA: CLOUDWF-2902