### PR TITLE
Use fedora base image from quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Upgrade to a more recent fedora version
-FROM fedora:32
+FROM quay.io/fedora/fedora:32-x86_64
 
 LABEL \
     name="Freshmaker application" \


### PR DESCRIPTION
Pulling fedora base image from docker registry can reach to pull rate
limit, and image build job will fail due to that, change base image to
fedora from quay.io.

Resolves: #48