### PR TITLE
Fix CI with mypy 0.800

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ description = type check
 deps =
     mypy
 commands =
-        mypy --ignore-missing-imports .
+        mypy --ignore-missing-imports freshmaker tests
 
 [testenv:bandit]
 basepython = python3


### PR DESCRIPTION
With new mypy 0.800 there are errors while checking against docs
directory, because mypy doesn't support excluding files/directories,
and since docs is not a module, we can't ignore the errors with:

    [mypy.docs]
    ignore_errors = True

In this change, we specify the directories to check explicitly to
workaround this.