### PR TITLE
Eus images support

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -204,6 +204,9 @@ class BaseConfiguration(object):
         }
     }
 
+    # repositories that should be searched for unpublished images, specifically because of EUS base images
+    UNPUBLISHED_EXCEPTIONS = []
+
 
 class DevConfiguration(BaseConfiguration):
     DEBUG = True

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -414,7 +414,13 @@ class Config(object):
             'type': str,
             'default': '',
             'desc': 'The API URL of the Product Pages service'
-        }
+        },
+        'unpublished_exceptions': {
+            'type': list,
+            'default': [],
+            'desc': 'List of dictionaries with unpublished repos, containing '
+                    '"registry" and "repository" keys that should not be ignored '
+                    'when searching for images to rebuild.'}
     }
 
     def __init__(self, conf_section_obj):
@@ -562,3 +568,14 @@ class Config(object):
         ccache_file = ccache_file.replace(
             "$pid", str(os.getpid()))
         return ccache_file
+
+    def _setifok_unpublished_exceptions(self, exceptions):
+        for exception in exceptions:
+            if not exception.get("registry", ""):
+                raise ValueError("There is no 'registry' or it's empty in one"
+                                 " of the UNPUBLISHED_EXCEPTIONS")
+
+            if not exception.get("repository", ""):
+                raise ValueError("There is no 'repository' or it's empty in one"
+                                 " of the UNPUBLISHED_EXCEPTIONS")
+        self._unpublished_exceptions = exceptions

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -1562,7 +1562,6 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         self.assertEqual(set(ret[2]["content_sets"]),
                          set(['dummy-content-set-1', 'dummy-content-set-2']))
 
-    @patch('freshmaker.lightblue.LightBlue.find_all_container_repositories')
     @patch('freshmaker.lightblue.LightBlue.find_images_with_packages_from_content_set')
     @patch('freshmaker.lightblue.LightBlue.find_parent_images_with_package')
     @patch('freshmaker.lightblue.LightBlue._filter_out_already_fixed_published_images')
@@ -1571,10 +1570,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
                                exists,
                                _filter_out_already_fixed_published_images,
                                find_parent_images_with_package,
-                               find_images_with_packages_from_content_set,
-                               find_repos):
+                               find_images_with_packages_from_content_set):
         exists.return_value = True
-        find_repos.return_value = {}
 
         image_a = ContainerImage.create({
             'brew': {'package': 'image-a', 'build': 'image-a-v-r1'},
@@ -1786,8 +1783,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "Couldn't find parent image some-original-nvr-7.6-252.1561619826. "
             "Lightblue data is probably incomplete"))
 
-    @patch('freshmaker.lightblue.LightBlue.find_all_container_repositories')
-    @patch('freshmaker.lightblue.LightBlue.get_images_by_nvrs')
+    @patch("freshmaker.lightblue.LightBlue.get_images_by_nvrs")
     @patch('freshmaker.lightblue.LightBlue.find_images_with_packages_from_content_set')
     @patch('freshmaker.lightblue.LightBlue.find_parent_images_with_package')
     @patch('freshmaker.lightblue.LightBlue._filter_out_already_fixed_published_images')
@@ -1795,9 +1791,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
     def test_parent_images_with_package_using_field_parent_brew_build_parent_empty(
             self, exists, _filter_out_already_fixed_published_images,
             find_parent_images_with_package, find_images_with_packages_from_content_set,
-            cont_images, find_repos):
+            cont_images):
         exists.return_value = True
-        find_repos.return_value = {}
 
         image_a = ContainerImage.create({
             "brew": {"package": "image-a", "build": "image-a-v-r1"},
@@ -1824,8 +1819,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         self.assertEqual(len(ret), 1)
         self.assertIsNotNone(ret[0][0].get("parent"))
 
-    @patch('freshmaker.lightblue.LightBlue.find_all_container_repositories')
-    @patch('freshmaker.lightblue.LightBlue.get_images_by_nvrs')
+    @patch("freshmaker.lightblue.LightBlue.get_images_by_nvrs")
     @patch('freshmaker.lightblue.LightBlue.find_images_with_packages_from_content_set')
     @patch('freshmaker.lightblue.LightBlue.find_parent_images_with_package')
     @patch('freshmaker.lightblue.LightBlue._filter_out_already_fixed_published_images')
@@ -1833,9 +1827,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
     def test_dedupe_dependency_images_with_all_repositories(
             self, exists, _filter_out_already_fixed_published_images,
             find_parent_images_with_package, find_images_with_packages_from_content_set,
-            get_images_by_nvrs, find_repos):
+            get_images_by_nvrs):
         exists.return_value = True
-        find_repos.return_value = {}
 
         vulnerable_rpm_name = 'oh-noes'
         vulnerable_rpm_nvr = '{}-1.0-1'.format(vulnerable_rpm_name)
@@ -3154,51 +3147,3 @@ def test_get_fixed_published_image_not_found_by_nvr(mock_fci, mock_exists):
     )
 
     assert image is None
-
-
-@patch('os.path.exists', return_value=True)
-@patch('freshmaker.lightblue.LightBlue.find_container_repositories')
-def test_is_latest_eus_image(find_repos, mock_exists):
-    images = [
-        # EUS tagged with auto_rebuild tag
-        {'repositories': [{'repository': 'some_repo/rhel',
-                           'tags': [{'name': 'tag1'}, {'name': 'tag2'}]
-                           },
-                          {'repository': 'rhel9-9-els/rhel-999',
-                           'tags': [{'name': 'tag1'}, {'name': 'latest'}]
-                           }
-                          ]
-         },
-        # EUS not tagged with auto_rebuild
-        {'repositories': [{'repository': 'rhel8-2-els/rhel',
-                           'tags': [{'name': 'tag1'}, {'name': 'tag2'}]
-                           },
-                          {'repository': 'rh-osbs/rhel',
-                           'tags': [{'name': 'latest'}]
-                           }
-                          ]
-         },
-        # repo names similar to EUS names tagged with auto_rebuild
-        {'repositories': [{'repository': 'some_repo-els1/rhel',
-                           'tags': [{'name': 'latest'}]
-                           },
-                          {'repository': 'some_repo-1els/rhel',
-                           'tags': [{'name': 'latest'}]
-                           },
-                          {'repository': 'rh-osbs/rhel-qels',
-                           'tags': [{'name': 'latest'}]
-                           },
-                          {'repository': 'rh-osbs/rhel-elsq',
-                           'tags': [{'name': 'latest'}]
-                           },
-                          ]
-         },
-    ]
-    find_repos.return_value = [{'auto_rebuild_tags': ['latest']}]
-    lb = LightBlue("lb.domain.local", "/path/to/cert", "/path/to/key")
-
-    results = []
-    for image in images:
-        results.append(lb.is_latest_eus_image(image))
-    assert results == [True, False, False]
-    assert find_repos.call_count == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,8 +35,7 @@ from tests import helpers
 def test_get_rebuilt_nvr(mock_time, rebuilt_nvr_release_suffix):
     nvr = "python-v3.6-201910221723"
     expected = f"{nvr}.1572631468{rebuilt_nvr_release_suffix}"
-    with patch.object(conf, "rebuilt_nvr_release_suffix",
-                      new=rebuilt_nvr_release_suffix):
+    with patch.object(conf, "rebuilt_nvr_release_suffix", new=rebuilt_nvr_release_suffix):
         rebuilt_nvr = get_rebuilt_nvr(ArtifactType.IMAGE.value, nvr)
     assert rebuilt_nvr == expected
 


### PR DESCRIPTION
Reverting commit that make EUS images marked as **directly_affected** + modify Lightblue module to query unpublished repositories specified in configuration file.