### PR TITLE
Add repo ids to content sets

### DIFF
--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -387,6 +387,10 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
                     username=conf.pulp_username,
                     password=conf.pulp_password)
         content_sets = pulp.get_content_set_by_repo_ids(pulp_repo_ids)
+        # Some container builds declare Pulp repos directly instead of content
+        # sets, but they are stored in the same location as content sets so they
+        # can be treated the same
+        content_sets.extend(pulp_repo_ids)
 
         self.log_info('RPMs from advisory ends up in following content sets: '
                       '%s', content_sets)

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -472,7 +472,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             pass
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['httpd-2.4-11.el7'], ['content-set-1'],
+            ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
             leaf_container_images=None)
@@ -489,7 +489,8 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             pass
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['httpd-2.4-11.el7', 'httpd-2.2-11.el6'], ['content-set-1'],
+            ['httpd-2.4-11.el7', 'httpd-2.2-11.el6'],
+            ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
             leaf_container_images=None)
@@ -508,7 +509,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             pass
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['httpd-2.4-11.el7'], ['content-set-1'],
+            ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=None, release_categories=None,
             leaf_container_images=None)
@@ -525,7 +526,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             pass
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['httpd-2.4-11.el7'], ['content-set-1'],
+            ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
             leaf_container_images=None)
@@ -543,7 +544,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             pass
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['httpd-2.4-11.el7'], ['content-set-1'],
+            ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
             leaf_container_images=["foo", "bar"])
@@ -561,7 +562,8 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
         self.handler._find_images_to_rebuild(123456)
 
         self.find_images_to_rebuild.assert_called_once_with(
-            ['nodejs-10.19.0-1.module+el8.1.0+5726+6ed65f8c.x86_64'], ['content-set-1'],
+            ['nodejs-10.19.0-1.module+el8.1.0+5726+6ed65f8c.x86_64'],
+            ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
             leaf_container_images=None)


### PR DESCRIPTION
Now content_sets list will consist of pulp
repository ids and content sets assiciated with those repositories

JIRA: CWFHEALTH-22

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>