### PR TITLE
Don't generate compose for EUS images

### DIFF
--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -217,3 +217,21 @@ def get_ocp_release_date(ocp_version):
     if not resp.ok:
         resp.raise_for_status()
     return resp.json()[0]['date_finish']
+
+
+def is_in_unpublished_exceptions(image):
+    """
+    Check if image is published in one of the repositories that is in
+    'unpublished_exceptions' configuration list.
+
+    :param ContainerImage image: image that should be checked
+    :return: True if image is published in 'exceptions' repository, False otherwise
+    """
+    repo_reg_pairs = {
+        (image_repo["repository"], image_repo["registry"])
+        for image_repo in image["repositories"]
+    }
+    return any(
+        (exception["repository"], exception["registry"]) in repo_reg_pairs
+        for exception in conf.unpublished_exceptions
+    )

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -65,6 +65,10 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
         self.mock_find_images_to_rebuild = self.patcher.patch(
             '_find_images_to_rebuild')
 
+        self.patcher.patch(
+            'freshmaker.handlers.koji.rebuild_images_on_rpm_advisory_change.is_in_unpublished_exceptions',
+            return_value=False)
+
         # Fake images found to rebuild has these relationships
         #
         # Batch 1  |         Batch 2            |          Batch 3
@@ -801,6 +805,10 @@ class TestBatches(helpers.ModelsTestCase):
         self.patcher = helpers.Patcher(
             'freshmaker.handlers.koji.RebuildImagesOnRPMAdvisoryChange.')
 
+        self.patcher.patch(
+            'freshmaker.handlers.koji.rebuild_images_on_rpm_advisory_change.is_in_unpublished_exceptions',
+            return_value=False)
+
     def tearDown(self):
         super(TestBatches, self).tearDown()
         self.patcher.unpatch_all()
@@ -1008,6 +1016,9 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
 
         self.patcher.patch_dict(
             'freshmaker.models.EVENT_TYPES', {self.mock_event.__class__: 0})
+
+        self.patcher.patch('freshmaker.handlers.koji.rebuild_images_on_rpm_advisory_change.is_in_unpublished_exceptions',
+                           return_value=False)
 
     def tearDown(self):
         super(TestRecordBatchesImages, self).tearDown()


### PR DESCRIPTION
Freshmaker will not generate ODCS compose for unpublished images that
suppose to be rebuilt.

JIRA: CWFHEALTH-208

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>