### PR TITLE
Make unpublished_exceptions only apply to container repos

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -904,36 +904,13 @@ class LightBlue(object):
             from.
         :param list rpm_nvrs_names: list names of the binary RPM NVRs to look for
         :param set auto_rebuild_tags: set of auto rebuild tags to add to query
-        :param bool published: whether to limit queries to published
-            repositories(some unpublished repos still will be queried)
+        :param bool published: whether to limit queries to images that are published
+            in a repository
         """
-        repo_filters = []
-        if published is not None:
-            repo_filters.append({"field": "repositories.*.published", "op": "=",
-                                 "rvalue": published})
-
-            # If the query is for published images, add configurable repos  for
-            # unpublished images(like EUS) too, because they shouldn't be ignored
-            if published and conf.unpublished_exceptions:
-                for repo in conf.unpublished_exceptions:
-                    repo_filters.append(
-                        {
-                            "$and": [
-                                {"field": "repositories.*.published", "op": "=",
-                                 "rvalue": False},
-                                {"field": "repositories.*.registry", "op": "=",
-                                 "rvalue": repo["registry"]},
-                                {"field": "repositories.*.repository",
-                                 "op": "=", "rvalue": repo["repository"]},
-                            ]
-                        }
-                    )
-
         query = {"$and": []}
-        if len(repo_filters) == 1:
-            query["$and"].append(repo_filters[0])
-        if len(repo_filters) > 1:
-            query["$and"].append({"$or": [r for r in repo_filters]})
+        if published is not None:
+            query["$and"].append({"field": "repositories.*.published", "op": "=",
+                                  "rvalue": published})
 
         if auto_rebuild_tags:
             query["$and"].append(

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -1110,12 +1110,6 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             self.fake_repositories_with_content_sets}
         self.assertEqual(ret, expected_ret)
 
-    @patch.object(freshmaker.conf, 'unpublished_exceptions', new=[
-        {'registry': 'unpublished_registry_1',
-         'repository': 'unpublished_repo_1'},
-        {'registry': 'unpublished_registry_2',
-         'repository': 'unpublished_repo_2'}
-    ])
     @patch('freshmaker.lightblue.LightBlue.find_container_images')
     @patch('os.path.exists')
     def test_find_images_with_included_srpm(self, exists, cont_images):
@@ -1136,38 +1130,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "objectType": "containerImage",
             "query": {
                 "$and": [
-                    {
-                        "$or": [
-                            {"field": "repositories.*.published", "op": "=",
-                             "rvalue": True},
-                            {
-                                "$and": [
-                                    {"field": "repositories.*.published",
-                                     "op": "=",
-                                     "rvalue": False},
-                                    {"field": "repositories.*.registry",
-                                     "op": "=",
-                                     "rvalue": "unpublished_registry_1"},
-                                    {"field": "repositories.*.repository",
-                                     "op": "=",
-                                     "rvalue": "unpublished_repo_1"}
-                                ]
-                            },
-                            {
-                                "$and": [
-                                    {"field": "repositories.*.published",
-                                     "op": "=",
-                                     "rvalue": False},
-                                    {"field": "repositories.*.registry",
-                                     "op": "=",
-                                     "rvalue": "unpublished_registry_2"},
-                                    {"field": "repositories.*.repository",
-                                     "op": "=",
-                                     "rvalue": "unpublished_repo_2"}
-                                ]
-                            }
-                        ]
-                    },
+                    {"field": "repositories.*.published", "op": "=", "rvalue": True},
                     {
                         "field": "repositories.*.tags.*.name", "op": "$in",
                         "values": ["latest", "tag1", "tag2"]


### PR DESCRIPTION
Unpublished exceptions for images such as EUS only matter at the
repository level. The repositories[].published value on a containerImage
entity is different according to Release Engineers.

This is based on the following statement from a Release Engineer:
>  I think that there is a published flag at the image level,
    which is true to indicate that the image is published in the repo.
    And there is another flag at the repo level to indicate whether the
    repo is visible in RHEC.