### PR TITLE
Logging ODCS compose state change

### DIFF
--- a/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
+++ b/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
@@ -50,6 +50,9 @@ class UpdateDBOnODCSComposeFail(BaseHandler):
             Compose.odcs_compose_id == event.compose["id"],
             ArtifactBuildCompose.compose_id == Compose.id)
 
+        if builds_with_compose:
+            self.log_error("ODCS compose %s failed", event.compose["id"])
+
         for build in builds_with_compose:
             build.transition(
                 ArtifactBuildState.FAILED.value,

--- a/freshmaker/handlers/koji/rebuild_images_on_odcs_compose_done.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_odcs_compose_done.py
@@ -53,6 +53,10 @@ class RebuildImagesOnODCSComposeDone(ContainerBuildHandler):
             ArtifactBuild.state == ArtifactBuildState.PLANNED.value,
             Compose.odcs_compose_id == event.compose['id'],
             ArtifactBuildCompose.compose_id == Compose.id)
+
+        if builds_ready_to_rebuild:
+            self.log_info('ODCS compose %s finished', event.compose['id'])
+
         # ... and depending on DONE parent image or parent image which is
         # not planned to be built in this Event (dep_on == None).
         builds_ready_to_rebuild = [


### PR DESCRIPTION
When see a message of ODCS compose state change, logging it so we can
check logs to know whether Freshmaker saw this message. And only logging
when this ODCS compose is connected with some builds.