### PR TITLE
Submit bundle builds to OSBS

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -240,6 +240,8 @@ class TestConfiguration(BaseConfiguration):
     LOG_LEVEL = 'debug'
     DEBUG = True
 
+    FRESHMAKER_ROOT_URL = "https://localhost"  # Root url of Freshmaker's endpoints
+
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
     MESSAGING = 'in_memory'

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -420,7 +420,13 @@ class Config(object):
             'default': [],
             'desc': 'List of dictionaries with unpublished repos, containing '
                     '"registry" and "repository" keys that should not be ignored '
-                    'when searching for images to rebuild.'}
+                    'when searching for images to rebuild.'
+        },
+        'freshmaker_root_url': {
+            'type': str,
+            'default': '',
+            'desc': 'Root of the API URL of Freshmaker'
+        },
     }
 
     def __init__(self, conf_section_obj):


### PR DESCRIPTION
Since we already know digests of bundle images that should be rebuilt,
now build objects are created for every image and submitted to OSBS.
Besides the other common information about build, pullspec overrides url is
submitted to OSBS.

JIRA: CWFHEALTH-104

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>