### PR TITLE
Determine the CSV modifications to send to the build system

### DIFF
--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -163,7 +163,7 @@ class Pyxis(object):
                 continue
 
             request_params['filter'] = \
-                f'latest_in_channel==true&source_index_container_path=={path}'
+                f'latest_in_channel==true%20and%20source_index_container_path=={path}'
             # Discard any bundles with invalid semantic versions since Freshmaker
             # would not be able to modify the version appropriately.
             bundle_list = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tabulate
 prometheus_client
 defusedxml
 rpm-py-installer
+semver

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -435,13 +435,13 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
                  {'include': 'data.channel_name,data.version,'
                              'data.related_images,data.bundle_path_digest,'
                              'data.bundle_path,data.csv_name',
-                  'filter': 'latest_in_channel==true&'
+                  'filter': 'latest_in_channel==true%20and%20'
                             'source_index_container_path==path/to/registry:v4.5'}),
             call('operators/bundles',
                  {'include': 'data.channel_name,data.version,'
                              'data.related_images,data.bundle_path_digest,'
                              'data.bundle_path,data.csv_name',
-                  'filter': 'latest_in_channel==true&'
+                  'filter': 'latest_in_channel==true%20and%20'
                             'source_index_container_path==path/to/registry:v4.6'}),
         ])
 

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -36,6 +36,7 @@ python3-rpm
 python3-setuptools
 python3-sqlalchemy
 python3-systemd
+python3-semver
 python3-tabulate
 python3-vcrpy
 systemd


### PR DESCRIPTION
When Freshmaker rebuilds bundle images, it must modify some attributes in the ClusterServiceVersion (CSV) file of the bundle
image so that it is added to the upgrade graph appropriately in an index image.

Resolves CWFHEALTH-76