### PR TITLE
Add manual bundle rebuild functionality

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -459,3 +459,13 @@ class BotasErrataShippedEvent(ErrataBaseEvent):
 
     def __init__(self, msg_id, advisory, dry_run=False):
         super().__init__(msg_id, advisory, dry_run=dry_run)
+
+
+class ManualBundleRebuild(BaseEvent):
+    def __init__(self, msg_id, container_images, bundle_images, metadata=None,
+                 dry_run=False, requester=None):
+        super().__init__(msg_id, manual=True, dry_run=dry_run)
+        self.container_images = container_images
+        self.bundle_images = bundle_images
+        self.metadata = metadata
+        self.requester = requester

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -46,7 +46,8 @@ from freshmaker.events import (
     ErrataAdvisoryRPMsSignedEvent, BrewContainerTaskStateChangeEvent,
     ErrataAdvisoryStateChangedEvent, FreshmakerManualRebuildEvent,
     ODCSComposeStateChangeEvent, ManualRebuildWithAdvisoryEvent,
-    FreshmakerAsyncManualBuildEvent, BotasErrataShippedEvent)
+    FreshmakerAsyncManualBuildEvent, BotasErrataShippedEvent,
+    ManualBundleRebuild)
 
 EVENT_TYPES = {
     MBSModuleStateChangeEvent: 0,
@@ -65,6 +66,7 @@ EVENT_TYPES = {
     ManualRebuildWithAdvisoryEvent: 13,
     FreshmakerAsyncManualBuildEvent: 14,
     BotasErrataShippedEvent: 15,
+    ManualBundleRebuild: 16,
 }
 
 INVERSE_EVENT_TYPES = {v: k for k, v in EVENT_TYPES.items()}

--- a/freshmaker/parsers/internal/manual_rebuild.py
+++ b/freshmaker/parsers/internal/manual_rebuild.py
@@ -21,7 +21,7 @@
 
 import time
 from freshmaker.parsers import BaseParser
-from freshmaker.events import ManualRebuildWithAdvisoryEvent
+from freshmaker.events import ManualRebuildWithAdvisoryEvent, ManualBundleRebuild
 from freshmaker.errata import Errata, ErrataAdvisory
 
 
@@ -44,16 +44,21 @@ class FreshmakerManualRebuildParser(BaseParser):
             from the UMB message sent from Frontend to Backend.
         """
         msg_id = data.get('msg_id', "manual_rebuild_%s" % (str(time.time())))
-        errata_id = data.get('errata_id')
         dry_run = data.get('dry_run', False)
 
-        errata = Errata()
-        advisory = ErrataAdvisory.from_advisory_id(errata, errata_id)
+        if data.get('errata_id', None):
+            errata_id = data.get('errata_id')
+            errata = Errata()
+            advisory = ErrataAdvisory.from_advisory_id(errata, errata_id)
 
-        event = ManualRebuildWithAdvisoryEvent(
-            msg_id, advisory, data.get("container_images", []), data.get("metadata", None),
-            freshmaker_event_id=data.get('freshmaker_event_id'), manual=True,
-            dry_run=dry_run, requester=data.get('requester', None))
+            event = ManualRebuildWithAdvisoryEvent(
+                msg_id, advisory, data.get("container_images", []), data.get("metadata", None),
+                freshmaker_event_id=data.get('freshmaker_event_id'), manual=True,
+                dry_run=dry_run, requester=data.get('requester', None))
+        else:
+            event = ManualBundleRebuild(msg_id, data.get('container_images', []),
+                                        data.get('bundle_images'), data.get('metadata', None),
+                                        dry_run=dry_run, requester=data.get('requester', None))
 
         return event
 

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -209,6 +209,21 @@ class Pyxis(object):
 
         return ret
 
+    def get_bundles_by_digest(self, digest):
+        """
+        Get bundles that have the specified digest in 'bundle_path_digest'.
+
+        :param str digest: digest of bundle image to search for
+        :return: list of bundles
+        :rtype: list
+        """
+        request_params = {
+            'include': ','.join(['data.version', 'data.csv_name']),
+            'filter': f'bundle_path_digest=={digest}'
+        }
+
+        return self._pagination('operators/bundles', request_params)
+
     def get_images_by_digest(self, digest):
         """
         Get images by image's digest (manifest_list_digest or manifest_schema2_digest)

--- a/freshmaker/views.py
+++ b/freshmaker/views.py
@@ -378,18 +378,23 @@ def _validate_rebuild_request(request):
                 400, 'Bad Request', 'The provided "freshmaker_event_id" is invalid.',
             )
 
+    if 'errata_id' in data and 'bundle_images' in data:
+        return json_error(400, 'Bad Request', '"errata_id" and "bundle_images" '
+                                              'can\'t be in the same request.')
+
     for key in ('dist_git_branch', 'brew_target'):
         if data.get(key) and not isinstance(data[key], str):
             return json_error(400, 'Bad Request', f'"{key}" must be a string.')
 
-    container_images = data.get('container_images', [])
-    if (
-        not isinstance(container_images, list) or
-        any(not isinstance(image, str) for image in container_images)
-    ):
-        return json_error(
-            400, 'Bad Request', '"container_images" must be an array of strings.',
-        )
+    for key in ('container_images', 'bundle_images'):
+        temp_list = data.get(key, [])
+        if (
+            not isinstance(temp_list, list) or
+            any(not isinstance(elem, str) for elem in temp_list)
+        ):
+            return json_error(
+                400, 'Bad Request', f'"{key}" must be an array of strings.',
+            )
 
     if not isinstance(data.get('dry_run', False), bool):
         return json_error(400, 'Bad Request', '"dry_run" must be a boolean.')
@@ -472,6 +477,18 @@ class BuildAPI(MethodView):
                 "errata_id": 12345
             }
 
+        **Sample request**:
+
+        .. sourcecode:: http
+
+            POST /api/1/builds HTTP/1.1
+            Accept: application/json
+            Content-Type: application/json
+
+            {
+                "bundle_images": ["app-bundle-1.0-1.11111"],
+            }
+
 
         :jsonparam string errata_id: The ID of Errata advisory to rebuild
             artifacts for. If this is not set, freshmaker_event_id must be set.
@@ -485,6 +502,8 @@ class BuildAPI(MethodView):
             this event will be reused in the newly created event instead of
             building all the artifacts from scratch. If errata_id is not
             provided, it will be inherited from this Freshmaker event.
+        :jsonparam list bundle_images: list of images to search Freshmaker
+            database for rebuild events with them
         :statuscode 200: A new event was created.
         :statuscode 400: The provided input is invalid.
         """
@@ -493,11 +512,15 @@ class BuildAPI(MethodView):
             return error
 
         data = request.get_json(force=True)
-        if not data.get('errata_id') and not data.get('freshmaker_event_id'):
+        if (
+            not data.get('errata_id') and not data.get('freshmaker_event_id') and
+            not data.get('bundle_images')
+        ):
             return json_error(
                 400,
                 'Bad Request',
-                'You must at least provide "errata_id" or "freshmaker_event_id" in the request.',
+                'You must at least provide "errata_id" or "freshmaker_event_id"'
+                ' or "bundle_images" in the request.',
             )
 
         dependent_event = None
@@ -756,9 +779,14 @@ class PullspecOverrideAPI(MethodView):
     @freshmaker_build_api_latency.time()
     def get(self, id):
         build = models.ArtifactBuild.query.filter_by(id=id).first()
-        # 'bundle_pullspec_overrides' should already contain valid JSON
         if build:
-            return jsonify(build.bundle_pullspec_overrides), 200
+            pullspec_overrides = build.bundle_pullspec_overrides
+            # remove old pullspec from output, since it used only internally for manual rebuilds
+            if pullspec_overrides and "pullspecs" in pullspec_overrides:
+                for pullspec in pullspec_overrides["pullspecs"]:
+                    if "_old" in pullspec:
+                        del pullspec["_old"]
+            return jsonify(pullspec_overrides), 200
         else:
             return json_error(404, "Not Found", "No such bundle build")
 

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -465,6 +465,18 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
         expected_bundles = [self.bundles[0]]
         self.assertListEqual(new_bundles, expected_bundles)
 
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_bundles_by_digest(self, page):
+        page.return_value = {"some_bundle"}
+        digest = "some_digest"
+
+        self.px.get_bundles_by_digest(digest)
+
+        page.assert_called_once_with("operators/bundles", {
+            "include": "data.version,data.csv_name",
+            "filter": "bundle_path_digest==some_digest"
+        })
+
     @patch('freshmaker.pyxis.requests.get')
     def test_get_images_by_digest(self, mock_get):
         image_1 = {


### PR DESCRIPTION
Release driver will send manual request for bundle rebuild to Freshmaker
in format:
{
  "container_images": ["app-bundle-1.0-1.22222"],
  "bundle_images": ["app-bundle-1.0-1.11111"],
  "metadata": release_driver_metadata,
}

Freshmaker will check pullspecs overrides of 'bundle_images'(the
original overwritten values) and if some of them are the same as the
current pullspec overrides in 'container_images' bundles. Then those
bundles(from 'container_images') will be rebuilt with the new pullspec overrides.

JIRA: CWFHEALTH-332

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>