### PR TITLE
Fix Pyxis filter request param in get_latest_bundles

### DIFF
--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -163,7 +163,7 @@ class Pyxis(object):
                 continue
 
             request_params['filter'] = \
-                f'latest_in_channel==true%20and%20source_index_container_path=={path}'
+                f'latest_in_channel==true and source_index_container_path=={path}'
             # Discard any bundles with invalid semantic versions since Freshmaker
             # would not be able to modify the version appropriately.
             bundle_list = [

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -435,13 +435,13 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
                  {'include': 'data.channel_name,data.version,'
                              'data.related_images,data.bundle_path_digest,'
                              'data.bundle_path,data.csv_name',
-                  'filter': 'latest_in_channel==true%20and%20'
+                  'filter': 'latest_in_channel==true and '
                             'source_index_container_path==path/to/registry:v4.5'}),
             call('operators/bundles',
                  {'include': 'data.channel_name,data.version,'
                              'data.related_images,data.bundle_path_digest,'
                              'data.bundle_path,data.csv_name',
-                  'filter': 'latest_in_channel==true%20and%20'
+                  'filter': 'latest_in_channel==true and '
                             'source_index_container_path==path/to/registry:v4.6'}),
         ])
 


### PR DESCRIPTION
change

    f'latest_in_channel==true%20and%20source_index_container_path=={path}'
to
    f'latest_in_channel==true and source_index_container_path=={path}'

requests.get will encode the params, no necessary to encode it before
sending the request, and it will result in bad request.