### PR TITLE
Get image digest from non-osbs registry repository

### DIFF
--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -191,7 +191,10 @@ class Pyxis(object):
         # get manifest_list_digest of ContainerImage from Pyxis
         for image in self._pagination(f'images/nvr/{nvr}', request_params):
             for repo in image.get('repositories'):
-                if repo['published'] and 'manifest_list_digest' in repo:
+                # skip internal build registry
+                if repo['registry'] in conf.image_build_repository_registries:
+                    continue
+                if 'manifest_list_digest' in repo:
                     return repo['manifest_list_digest']
         return None
 

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -445,6 +445,7 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
                             'source_index_container_path==path/to/registry:v4.6'}),
         ])
 
+    @patch.object(conf, 'image_build_repository_registries', new=['reg1'])
     @patch('freshmaker.pyxis.Pyxis._pagination')
     def test_get_manifest_list_digest_by_nvr(self, page):
         page.return_value = self.images


### PR DESCRIPTION
Internal testing images will not be published, and the repository will be
unpublished, getting image digests from published repository will block
the testing with these images, so just skip osbs registry repositories
to allow getting digest from unpublished repositories.