### PR TITLE
Allow manifest list digests from unpublished repositories

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -153,7 +153,10 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         rebuilt_digests_by_nvr = {}
         rebuilt_nvrs = nvrs_mapping.values()
         for nvr in rebuilt_nvrs:
-            digest = self._pyxis.get_manifest_list_digest_by_nvr(nvr)
+            # Don't require that the manifest list digest be published in this case because
+            # there's a delay from after an advisory is shipped and when the published repositories
+            # entry is populated
+            digest = self._pyxis.get_manifest_list_digest_by_nvr(nvr, must_be_published=False)
             if digest:
                 rebuilt_digests_by_nvr[nvr] = digest
             else:

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -178,11 +178,13 @@ class Pyxis(object):
 
         return latest_bundles
 
-    def get_manifest_list_digest_by_nvr(self, nvr):
+    def get_manifest_list_digest_by_nvr(self, nvr, must_be_published=True):
         """
         Get image's digest(manifest_list_digest field) by its NVR
 
         :param str nvr: NVR of ContainerImage to query Pyxis
+        :param bool must_be_published: determines if the image must be published to the repository
+            that the manifest list digest is retrieved from
         :return: digest of image or None if manifest_list_digest not exists
         :rtype: str or None
         """
@@ -190,8 +192,10 @@ class Pyxis(object):
 
         # get manifest_list_digest of ContainerImage from Pyxis
         for image in self._pagination(f'images/nvr/{nvr}', request_params):
-            for repo in image.get('repositories'):
-                if repo['published'] and 'manifest_list_digest' in repo:
+            for repo in image['repositories']:
+                if must_be_published and not repo['published']:
+                    continue
+                if 'manifest_list_digest' in repo:
                     return repo['manifest_list_digest']
         return None
 

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -457,6 +457,36 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
             {'include': 'data.brew,data.repositories'}
         )
 
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_manifest_list_digest_by_nvr_unpublished(self, page):
+        page.return_value = [
+            {
+                "brew": {
+                    "build": "s2i-1-2",
+                    "completion_date": "2020-08-12T11:31:39+00:00",
+                    "nvra": "s2i-1-2.arm64",
+                    "package": "s2i-core-container"
+                },
+                "repositories": [
+                    {
+                        "manifest_list_digest": "sha256:4444",
+                        "published": False,
+                        "registry": "reg4",
+                        "repository": "repo4",
+                        "tags": [{"name": "tag1"}]
+                    }
+                ]
+            }
+        ]
+        digest = self.px.get_manifest_list_digest_by_nvr('s2i-1-2', False)
+
+        expected_digest = 'sha256:4444'
+        self.assertEqual(digest, expected_digest)
+        page.assert_called_once_with(
+            'images/nvr/s2i-1-2',
+            {'include': 'data.brew,data.repositories'}
+        )
+
     def test_get_bundles_by_related_image_digest(self):
         digest = 'sha256:111'
         new_bundles = self.px.get_bundles_by_related_image_digest(


### PR DESCRIPTION
The issue is that there is a delay from when a BOTAS advisory
is shipped and when Pyxis is updated with the published
repositories entry on the image. The manifest list digest
is the same in both cases, so it's safe to fallback to the
unpublished manifest list digest value for this case.