### PR TITLE
Specify a null original parent for bundle image rebuilds

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -692,6 +692,10 @@ class HandleBotasAdvisory(ContainerBuildHandler):
                 "target": additional_data["target"],
                 "branch": additional_data["git_branch"],
                 "arches": additional_data["arches"],
+                # The build system always enforces that bundle images build from
+                # "scratch", so there is no parent image. See:
+                # https://osbs.readthedocs.io/en/latest/users.html?#operator-manifest-bundle-builds
+                "original_parent": None,
                 "operator_csv_modifications_url": csv_mod_url.format(build.id),
             })
             build.bundle_pullspec_overrides = {

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -824,6 +824,16 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             },
         }
         self.assertEqual(submitted_build.bundle_pullspec_overrides, expected_csv_modifications)
+        expected_build_args = {
+            "repository": "repo",
+            "commit": "commit_1",
+            "target": "target_1",
+            "branch": "git_branch_1",
+            "arches": ["arch_1", "arch_1"],
+            "original_parent": None,
+            "operator_csv_modifications_url": "https://localhost/api/2/pullspec_overrides/1",
+        }
+        self.assertEqual(json.loads(submitted_build.build_args), expected_build_args)
         self.assertEqual(submitted_build.state, ArtifactBuildState.PLANNED.value)
         self.assertEqual(json.loads(submitted_build.build_args)["operator_csv_modifications_url"],
                          pullspec_override_url + str(submitted_build.id))


### PR DESCRIPTION
The build system always enforces that bundle images build from
"scratch", so there is no parent image. See:
https://osbs.readthedocs.io/en/latest/users.html?#operator-manifest-bundle-builds