### PR TITLE
Shorten the CSV version build ID suffix

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -491,9 +491,9 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         Get a bundle version for the Freshmaker rebuild of the bundle image.
 
         Examples:
-            1.2.3 => 1.2.3+0.$timestamp.patched (no build ID and not a rebuild)
-            1.2.3+48273 => 1.2.3+48273.0.$timestamp.patched (build ID and not a rebuild)
-            1.2.3+48273.0.1616457250.patched => 1.2.3+48273.0.$timestamp.patched (build ID and a rebuild)
+            1.2.3 => 1.2.3+0.$timestamp.p (no build ID and not a rebuild)
+            1.2.3+48273 => 1.2.3+48273.0.$timestamp.p (build ID and not a rebuild)
+            1.2.3+48273.0.1616457250.p => 1.2.3+48273.0.$timestamp.p (build ID and a rebuild)
 
         :param str version: the version of the bundle image being rebuilt
         :return: a tuple of the bundle version of the Freshmaker rebuild of the bundle image and
@@ -503,11 +503,12 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         parsed_version = semver.VersionInfo.parse(version)
         # Strip off the microseconds of the timestamp
         timestamp = int(datetime.utcnow().timestamp())
-        new_fm_suffix = f'0.{timestamp}.patched'
+        new_fm_suffix = f'0.{timestamp}.p'
         if parsed_version.build:
-            # Check if the bundle was a Freshmaker rebuild
+            # Check if the bundle was a Freshmaker rebuild. Include .patched
+            # for backwards compatibility with the old suffix.
             fm_suffix_search = re.search(
-                r'(?P<fm_suffix>0\.\d+\.patched)$', parsed_version.build
+                r'(?P<fm_suffix>0\.\d+\.(?:p|patched))$', parsed_version.build
             )
             if fm_suffix_search:
                 fm_suffix = fm_suffix_search.groupdict()['fm_suffix']

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -242,10 +242,10 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 ],
                 "update": {
                     "metadata": {
-                        "name": "image.1.2.3+0.1608854400.patched",
+                        "name": "image.1.2.3+0.1608854400.p",
                         "annotations": {"olm.substitutesFor": "1.2.3"},
                     },
-                    "spec": {"version": "1.2.3+0.1608854400.patched"},
+                    "spec": {"version": "1.2.3+0.1608854400.p"},
                 },
             },
             "bundle_with_related_images_2_digest": {
@@ -263,10 +263,10 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 ],
                 "update": {
                     "metadata": {
-                        "name": "image.1.2.4+0.1608854400.patched",
+                        "name": "image.1.2.4+0.1608854400.p",
                         "annotations": {"olm.substitutesFor": "1.2.4"},
                     },
-                    "spec": {"version": "1.2.4+0.1608854400.patched"},
+                    "spec": {"version": "1.2.4+0.1608854400.p"},
                 },
             },
         }
@@ -790,11 +790,11 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 }],
                 "update": {
                     "metadata": {
-                        'name': "amq-streams.2.2.0+0.1608854400.patched",
+                        'name': "amq-streams.2.2.0+0.1608854400.p",
                         "annotations": {"olm.substitutesFor": "2.2.0"},
                     },
                     'spec': {
-                        'version': "2.2.0+0.1608854400.patched",
+                        'version': "2.2.0+0.1608854400.p",
                     }
                 },
             }
@@ -815,11 +815,11 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             ],
             "update": {
                 "metadata": {
-                    "name": "amq-streams.2.2.0+0.1608854400.patched",
+                    "name": "amq-streams.2.2.0+0.1608854400.p",
                     "annotations": {"olm.substitutesFor": "2.2.0"},
                 },
                 "spec": {
-                    "version": "2.2.0+0.1608854400.patched",
+                    "version": "2.2.0+0.1608854400.p",
                 }
             },
         }
@@ -842,11 +842,16 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 @pytest.mark.parametrize(
     "version, expected",
     (
-        ("1.2.3", ("1.2.3+0.1608854400.patched", "0.1608854400.patched")),
-        ("1.2.3+beta3", ("1.2.3+beta3.0.1608854400.patched", "0.1608854400.patched")),
+        ("1.2.3", ("1.2.3+0.1608854400.p", "0.1608854400.p")),
+        ("1.2.3+beta3", ("1.2.3+beta3.0.1608854400.p", "0.1608854400.p")),
+        (
+            "1.2.3+beta3.0.1608853000.p",
+            ("1.2.3+beta3.0.1608854400.p", "0.1608854400.p"),
+        ),
+        # Test backwards compatibility with the old suffix
         (
             "1.2.3+beta3.0.1608853000.patched",
-            ("1.2.3+beta3.0.1608854400.patched", "0.1608854400.patched"),
+            ("1.2.3+beta3.0.1608854400.p", "0.1608854400.p"),
         ),
     )
 )
@@ -858,31 +863,31 @@ def test_get_rebuild_bundle_version(version, expected):
 
 def test_get_csv_name():
     version = "1.2.3"
-    rebuild_version = "1.2.3+0.1608854400.patched"
-    fm_suffix = "0.1608854400.patched"
+    rebuild_version = "1.2.3+0.1608854400.p"
+    fm_suffix = "0.1608854400.p"
     rv = HandleBotasAdvisory._get_csv_name("amq-streams.1.2.3", version, rebuild_version, fm_suffix)
-    assert rv == "amq-streams.1.2.3+0.1608854400.patched"
+    assert rv == "amq-streams.1.2.3+0.1608854400.p"
 
     # If the version is not present in the CSV name (it's supposed to be), then Freshmaker
     # will just append the suffix to make it unique
     rv = HandleBotasAdvisory._get_csv_name("amq-streams.123", version, rebuild_version, fm_suffix)
-    assert rv == "amq-streams.123.0.1608854400.patched"
+    assert rv == "amq-streams.123.0.1608854400.p"
 
 
 @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_csv_name")
 @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_rebuild_bundle_version")
 def test_get_csv_updates(mock_grbv, mock_gcn):
-    mock_grbv.return_value = ("1.2.3+0.1608854400.patched", "0.1608854400.patched")
-    mock_gcn.return_value = "amq-streams.1.2.3+0.1608854400.patched"
+    mock_grbv.return_value = ("1.2.3+0.1608854400.p", "0.1608854400.p")
+    mock_gcn.return_value = "amq-streams.1.2.3+0.1608854400.p"
     rv = HandleBotasAdvisory._get_csv_updates("amq-streams.1.2.3", "1.2.3")
     assert rv == {
         "update": {
             "metadata": {
-                'name': "amq-streams.1.2.3+0.1608854400.patched",
+                'name': "amq-streams.1.2.3+0.1608854400.p",
                 "annotations": {"olm.substitutesFor": "1.2.3"}
             },
             'spec': {
-                'version': "1.2.3+0.1608854400.patched",
+                'version': "1.2.3+0.1608854400.p",
             }
         }
     }

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,9 @@ commands = flake8
 
 [testenv:mypy]
 description = type check
+# Pin to an older version of mypy since 0.902 does not seem to ignore missing imports
 deps =
-    mypy
+    mypy==0.812
 commands =
         mypy --ignore-missing-imports freshmaker tests
 


### PR DESCRIPTION
There is a character limit of 63 characters for the
ClusterServiceVersion (CSV) name due to how they are used in Kubernetes
under the hood. This shortens the build ID suffix and thus shortens
the CSV name a little bit to meet the large majority bundle images.