### PR TITLE
Fix the HandleBotasAdvisory.handle method for manual rebuilds

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -469,3 +469,6 @@ class ManualBundleRebuild(BaseEvent):
         self.bundle_images = bundle_images
         self.metadata = metadata
         self.requester = requester
+
+    def is_allowed(self, handler, **kwargs):
+        return super().is_allowed(handler, ArtifactType.IMAGE, **kwargs)

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -107,6 +107,16 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         self.assertTrue(db_event.state_reason.startswith(
             "This image rebuild is not allowed by internal policy."))
 
+    def test_handle_manual_isnt_allowed_by_internal_policy(self):
+        event = ManualBundleRebuild("test_msg_id", [], [])
+
+        self.handler.handle(event)
+        db_event = Event.get(db.session, message_id='test_msg_id')
+
+        self.assertEqual(db_event.state, EventState.SKIPPED.value)
+        self.assertTrue(db_event.state_reason.startswith(
+            "This image rebuild is not allowed by internal policy."))
+
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory.start_to_build_images")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._prepare_builds")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._handle_auto_rebuild")


### PR DESCRIPTION
This fixes the error:
TypeError: is_allowed() missing 1 required positional argument: 'artifact_type'