### PR TITLE
WIP: Support manifest v2 digests for manual rebuilds

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -132,7 +132,7 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         original_digests_by_nvr = {}
         original_nvrs_by_digest = {}
         for nvr in original_nvrs:
-            digest = self._pyxis.get_manifest_list_digest_by_nvr(nvr)
+            digest, _ = self._pyxis.get_manifestv2_digests_by_nvr(nvr)
             if digest:
                 original_digests_by_nvr[nvr] = digest
                 original_nvrs_by_digest[digest] = nvr
@@ -156,7 +156,7 @@ class HandleBotasAdvisory(ContainerBuildHandler):
             # Don't require that the manifest list digest be published in this case because
             # there's a delay from after an advisory is shipped and when the published repositories
             # entry is populated
-            digest = self._pyxis.get_manifest_list_digest_by_nvr(nvr, must_be_published=False)
+            digest, _ = self._pyxis.get_manifestv2_digests_by_nvr(nvr, must_be_published=False)
             if digest:
                 rebuilt_digests_by_nvr[nvr] = digest
             else:
@@ -406,9 +406,9 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         to_rebuild_bundles = []
         # fill 'append' and 'update' fields for bundles to rebuild
         for nvr, pullspecs in rebuild_nvr_to_pullspecs_map.items():
-            bundle_digest = self._pyxis.get_manifest_list_digest_by_nvr(nvr)
-            if bundle_digest is not None:
-                bundles = self._pyxis.get_bundles_by_digest(bundle_digest)
+            list_digest, v2_digest = self._pyxis.get_manifestv2_digests_by_nvr(nvr)
+            if list_digest is not None:
+                bundles = self._pyxis.get_bundles_by_digest(list_digest, v2_digest)
                 temp_bundle = bundles[0]
                 csv_updates = (self._get_csv_updates(temp_bundle['csv_name'],
                                                      temp_bundle['version']))


### PR DESCRIPTION
I ran into an issue when trying the manual bundle rebuilds and the digest in `bundle_path_digest` was a v2 manifest and not a manifest list.

I am marking this as WIP since I don't know if we want to accept this since I'm not realizing that the manual rebuild code relies on the operators/bundles Pyxis API endpoint be and many of these images will be not yet published and thus won't have such an entry.