### PR TITLE
Set olm.substitutesFor to the CSV name

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -497,7 +497,7 @@ class HandleBotasAdvisory(ContainerBuildHandler):
                 # Update the name of the CSV to something uniquely identify the rebuild
                 'name': new_csv_name,
                 # Declare that this rebuild is a substitute of the bundle being rebuilt
-                'annotations': {'olm.substitutesFor': version}
+                'annotations': {'olm.substitutesFor': csv_name}
             },
             'spec': {
                 # Update the version of the rebuild to be unique and a newer version than the

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -253,7 +253,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 "update": {
                     "metadata": {
                         "name": "image.1.2.3-0.1608854400.p",
-                        "annotations": {"olm.substitutesFor": "1.2.3"},
+                        "annotations": {"olm.substitutesFor": "image.1.2.3"},
                     },
                     "spec": {"version": "1.2.3+0.1608854400.p"},
                 },
@@ -274,7 +274,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 "update": {
                     "metadata": {
                         "name": "image.1.2.4-0.1608854400.p",
-                        "annotations": {"olm.substitutesFor": "1.2.4"},
+                        "annotations": {"olm.substitutesFor": "image.1.2.4"},
                     },
                     "spec": {"version": "1.2.4+0.1608854400.p"},
                 },
@@ -801,7 +801,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                 "update": {
                     "metadata": {
                         'name': "amq-streams.2.2.0+0.1608854400.p",
-                        "annotations": {"olm.substitutesFor": "2.2.0"},
+                        "annotations": {"olm.substitutesFor": "image.2.2.0"},
                     },
                     'spec': {
                         'version': "2.2.0+0.1608854400.p",
@@ -826,7 +826,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             "update": {
                 "metadata": {
                     "name": "amq-streams.2.2.0+0.1608854400.p",
-                    "annotations": {"olm.substitutesFor": "2.2.0"},
+                    "annotations": {"olm.substitutesFor": "image.2.2.0"},
                 },
                 "spec": {
                     "version": "2.2.0+0.1608854400.p",
@@ -904,7 +904,7 @@ def test_get_csv_updates(mock_grbv, mock_gcn):
         "update": {
             "metadata": {
                 'name': "amq-streams.1.2.3-0.1608854400.p",
-                "annotations": {"olm.substitutesFor": "1.2.3"}
+                "annotations": {"olm.substitutesFor": "amq-streams.1.2.3"}
             },
             'spec': {
                 'version': "1.2.3+0.1608854400.p",


### PR DESCRIPTION
This was previously set to the version which is incorrect.