### PR TITLE
Add manual retriggering of bundle rebuild

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -174,6 +174,7 @@ class Config(object):
                 'freshmaker.handlers.koji:RebuildImagesOnODCSComposeDone',
                 'freshmaker.handlers.bob:RebuildImagesOnImageAdvisoryChange',
                 'freshmaker.handlers.koji:RebuildImagesOnAsyncManualBuild',
+                'freshmaker.handlers.botas:HandleBotasAdvisory'
             ],
             'desc': 'List of enabled handlers.'},
         'polling_interval': {

--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -462,13 +462,33 @@ class BotasErrataShippedEvent(ErrataBaseEvent):
 
 
 class ManualBundleRebuild(BaseEvent):
-    def __init__(self, msg_id, container_images, bundle_images, metadata=None,
-                 dry_run=False, requester=None):
+    """
+    Event triggered when Release Driver requests manual rebuild
+    OR when manual rebuild of bundles requested by person
+    """
+    def __init__(self, msg_id, dry_run=False):
         super().__init__(msg_id, manual=True, dry_run=dry_run)
-        self.container_images = container_images
-        self.bundle_images = bundle_images
-        self.metadata = metadata
-        self.requester = requester
 
     def is_allowed(self, handler, **kwargs):
         return super().is_allowed(handler, ArtifactType.IMAGE, **kwargs)
+
+    @classmethod
+    def from_manual_rebuild_request(cls, msg_id, advisory,
+                                    freshmaker_event_id=None,
+                                    container_images=[], requester=None, **kwargs):
+        event = cls(msg_id, **kwargs)
+        event.advisory = advisory
+        event.freshmaker_event_id = freshmaker_event_id
+        event.container_images = container_images
+        event.requester = requester
+        return event
+
+    @classmethod
+    def from_release_driver_request(cls, msg_id, container_images, bundle_images,
+                                    metadata=None, requester=None, **kwargs):
+        event = cls(msg_id, **kwargs)
+        event.container_images = container_images
+        event.bundle_images = bundle_images
+        event.metadata = metadata
+        event.requester = requester
+        return event

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -84,10 +84,12 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         event = BotasErrataShippedEvent("123", self.botas_advisory)
         self.assertTrue(handler.can_handle(event))
 
-    def test_can_handle_manual_rebuild(self):
+    def test_can_handle_manual_rebuilds(self):
         handler = HandleBotasAdvisory()
-        event = ManualBundleRebuild("123", [], [])
-        self.assertTrue(handler.can_handle(event))
+        event1 = ManualBundleRebuild.from_manual_rebuild_request("123", None)
+        event2 = ManualBundleRebuild.from_release_driver_request("123", [], [])
+        self.assertTrue(handler.can_handle(event1))
+        self.assertTrue(handler.can_handle(event2))
 
     def test_handle_set_dry_run(self):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory,
@@ -108,25 +110,31 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             "This image rebuild is not allowed by internal policy."))
 
     def test_handle_manual_isnt_allowed_by_internal_policy(self):
-        event = ManualBundleRebuild("test_msg_id", [], [])
+        event1 = ManualBundleRebuild.from_manual_rebuild_request("test_msg_id1", None)
+        event2 = ManualBundleRebuild.from_release_driver_request("test_msg_id2", [], [])
 
-        self.handler.handle(event)
-        db_event = Event.get(db.session, message_id='test_msg_id')
+        self.handler.handle(event1)
+        self.handler.handle(event2)
+        db_event1 = Event.get(db.session, message_id='test_msg_id1')
+        db_event2 = Event.get(db.session, message_id='test_msg_id2')
 
-        self.assertEqual(db_event.state, EventState.SKIPPED.value)
-        self.assertTrue(db_event.state_reason.startswith(
+        self.assertEqual(db_event1.state, EventState.SKIPPED.value)
+        self.assertTrue(db_event1.state_reason.startswith(
+            "This image rebuild is not allowed by internal policy."))
+        self.assertEqual(db_event2.state, EventState.SKIPPED.value)
+        self.assertTrue(db_event2.state_reason.startswith(
             "This image rebuild is not allowed by internal policy."))
 
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory.start_to_build_images")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._prepare_builds")
-    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._handle_auto_rebuild")
+    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._handle_bundle_rebuild")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory.allow_build")
-    def test_handle(self, allow_build, handle_auto_rebuild, prepare_builds,
+    def test_handle(self, allow_build, handle_bundle_rebuild, prepare_builds,
                     start_to_build_images):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
         db_event = Event.get_or_create_from_event(db.session, event)
         allow_build.return_value = True
-        handle_auto_rebuild.return_value = [{"bundle": 1}, {"bundle": 2}]
+        handle_bundle_rebuild.return_value = [{"bundle": 1}, {"bundle": 2}]
         prepare_builds.return_value = [
             ArtifactBuild.create(db.session, db_event, "ed0", "image", 1234,
                                  original_nvr="some_name-2-12345",
@@ -143,17 +151,15 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         self.assertEqual(self.handler._prepare_builds.call_args[0][1],
                          [{"bundle": 1}, {"bundle": 2}])
 
-    def test_handle_auto_rebuild(self):
+    def test_handle_bundle_rebuild_auto(self):
+        """ Test handling of AUTOMATICALLY triggered bundle rebuild"""
+        # operators mapping
         nvr_to_digest = {
             "original_1": "original_1_digest",
             "some_name-1-12345": "some_name-1-12345_digest",
             "original_2": "original_2_digest",
             "some_name_2-2-2": "some_name_2-2-2_digest",
         }
-        bundles = [{"bundle_path_digest": "original_1_digest"},
-                   {"bundle_path_digest": "some_name-1-12345_digest"},
-                   {"bundle_path_digest": "original_2_digest"},
-                   {"bundle_path_digest": "some_name_2-2-2_digest"}]
         bundles_with_related_images = {
             "original_1_digest": [
                 {
@@ -222,8 +228,10 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             return nvr_to_digest[nvr]
         self.pyxis().get_manifest_list_digest_by_nvr.side_effect = gmldbn
         self.pyxis().get_operator_indices.return_value = []
-        self.pyxis().get_latest_bundles.return_value = bundles
-        # return bundles for original images
+        # Doens't matter what this method will return, because we override method
+        # that uses return value
+        self.pyxis().get_latest_bundles.return_value = ["some", "bundles", "info"]
+        # return bundles for original operator images
         self.pyxis().get_bundles_by_related_image_digest.side_effect = lambda x, y: bundles_with_related_images[x]
         self.pyxis().get_images_by_digest.side_effect = lambda x: [image_by_digest[x]]
         self.handler.image_has_auto_rebuild_tag = MagicMock(return_value=True)
@@ -232,7 +240,178 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 
         now = datetime(year=2020, month=12, day=25, hour=0, minute=0, second=0)
         with freezegun.freeze_time(now):
-            bundles_to_rebuild = self.handler._handle_auto_rebuild(db_event)
+            bundles_to_rebuild = self.handler._handle_bundle_rebuild(db_event)
+
+        self.assertNotEqual(db_event.state, EventState.SKIPPED.value)
+        get_build.assert_has_calls([call("bundle1_nvr-1-1"), call("bundle2_nvr-1-1")], any_order=True)
+        bundles_by_digest = {
+            "bundle_with_related_images_1_digest": {
+                "auto_rebuild": True,
+                "images": [{"brew": {"build": "bundle1_nvr-1-1"}}],
+                "nvr": "bundle1_nvr-1-1",
+                "osbs_pinning": True,
+                "pullspec_replacements": [
+                    {
+                        "new": "registry/repo/operator1@some_name-1-12345_digest",
+                        "original": "registry/repo/operator1:v2.2.0",
+                        "pinned": True,
+                        "_old": "registry/repo/operator1@original_1_digest"
+                    }
+                ],
+                "update": {
+                    "metadata": {
+                        "name": "image.1.2.3-0.1608854400.p",
+                        "annotations": {"olm.substitutesFor": "image.1.2.3"},
+                    },
+                    "spec": {"version": "1.2.3+0.1608854400.p"},
+                },
+            },
+            "bundle_with_related_images_2_digest": {
+                "auto_rebuild": True,
+                "images": [{"brew": {"build": "bundle2_nvr-1-1"}}],
+                "nvr": "bundle2_nvr-1-1",
+                "osbs_pinning": True,
+                "pullspec_replacements": [
+                    {
+                        "new": "registry/repo/operator2@some_name_2-2-2_digest",
+                        "original": "registry/repo/operator2:v2.2.0",
+                        "pinned": True,
+                        "_old": "registry/repo/operator2@original_2_digest"
+                    }
+                ],
+                "update": {
+                    "metadata": {
+                        "name": "image.1.2.4-0.1608854400.p",
+                        "annotations": {"olm.substitutesFor": "image.1.2.4"},
+                    },
+                    "spec": {"version": "1.2.4+0.1608854400.p"},
+                },
+            },
+        }
+        self.assertCountEqual(bundles_to_rebuild, list(bundles_by_digest.values()))
+
+    @patch('freshmaker.models.Event.get_artifact_build_from_event_dependencies')
+    def test_handle_bundle_rebuild_manual(self, get_dependent_event_build):
+        """ Test handling of MANUALLY triggered bundle rebuild"""
+        # operators mapping
+        nvr_to_digest = {
+            "original_1": "original_1_digest",
+            "some_name-1-12345": "some_name-1-12345_digest",
+            "original_2": "original_2_digest",
+            "some_name_2-2-2": "some_name_2-2-2_digest",
+            "some_name_3-3-3": "some_name_3-3-3_digest",
+            "some_name_4-4-4": "some_name_4-4-4_digest",
+            # operator for bundle ignored because of 'container_images'
+            "original_3": "original_3_digest",
+            # operator for bundle ignored because it was built in dependent event
+            "original_4": "original_4_digest"
+        }
+        # related image digest -> bundle
+        bundles_with_related_images = {
+            "original_1_digest": [
+                {
+                    "bundle_path_digest": "bundle_with_related_images_1_digest",
+                    "csv_name": "image.1.2.3",
+                    "version": "1.2.3",
+                },
+            ],
+            "original_2_digest": [
+                {
+                    "bundle_path_digest": "bundle_with_related_images_2_digest",
+                    "csv_name": "image.1.2.4",
+                    "version": "1.2.4",
+                },
+            ],
+            # bundle ignored because of 'container_images'
+            "original_3_digest": [
+                {
+                    "bundle_path_digest": "bundle_with_related_images_3_digest",
+                    "csv_name": "image.1.2.5",
+                    "version": "1.2.5",
+                },
+            ],
+            # bundle ignored because it was already built in dependent event
+            "original_4_digest": [
+                {
+                    "bundle_path_digest": "bundle_with_related_images_4_digest",
+                    "csv_name": "image.1.2.6",
+                    "version": "1.2.6",
+                },
+            ]
+        }
+        image_by_digest = {
+            "bundle_with_related_images_1_digest": {"brew": {"build": "bundle1_nvr-1-1"}},
+            "bundle_with_related_images_2_digest": {"brew": {"build": "bundle2_nvr-1-1"}},
+            "bundle_with_related_images_3_digest": {"brew": {"build": "bundle3_nvr-1-1"}},
+            "bundle_with_related_images_4_digest": {"brew": {"build": "bundle4_nvr-1-1"}},
+        }
+        builds = {
+            "bundle1_nvr-1-1": {
+                "task_id": 1,
+                "extra": {
+                    "image": {
+                        "operator_manifests": {
+                            "related_images": {
+                                "created_by_osbs": True,
+                                "pullspecs": [{
+                                    "new": "registry/repo/operator1@original_1_digest",
+                                    "original": "registry/repo/operator1:v2.2.0",
+                                    "pinned": True,
+                                }]
+                            },
+                        }
+                    }
+                }
+            },
+            "bundle2_nvr-1-1": {
+                "task_id": 2,
+                "extra": {
+                    "image": {
+                        "operator_manifests": {
+                            "related_images": {
+                                "created_by_osbs": True,
+                                "pullspecs": [{
+                                    "new": "registry/repo/operator2@original_2_digest",
+                                    "original": "registry/repo/operator2:v2.2.0",
+                                    "pinned": True,
+                                }]
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+        event = ManualBundleRebuild.from_manual_rebuild_request(
+            "test_msg_id", self.botas_advisory, "dependent_event_id",
+            container_images=["bundle1_nvr-1-1", "bundle2_nvr-1-1", "bundle4_nvr-1-1"])
+        db_event = Event.get_or_create_from_event(db.session, event)
+        self.handler.event = event
+        self.handler._create_original_to_rebuilt_nvrs_map = \
+            MagicMock(return_value={"original_1": "some_name-1-12345",
+                                    "original_2": "some_name_2-2-2",
+                                    "original_3": "some_name_3-3-3",
+                                    "original_4": "some_name_4-4-4"})
+
+        def gmldbn(nvr, must_be_published=True):
+            return nvr_to_digest[nvr]
+        self.pyxis().get_manifest_list_digest_by_nvr.side_effect = gmldbn
+        self.pyxis().get_operator_indices.return_value = []
+        # Doens't matter what this method will return, because we override method
+        # that uses return value
+        self.pyxis().get_latest_bundles.return_value = ["some", "bundles", "info"]
+        # return bundles for original operator images
+        self.pyxis().get_bundles_by_related_image_digest.side_effect = lambda x, y: bundles_with_related_images[x]
+        self.pyxis().get_images_by_digest.side_effect = lambda x: [image_by_digest[x]]
+        # ignore bundle because it was already built in dependent event
+        get_dependent_event_build.side_effect = lambda x: True if x == 'bundle4_nvr-1-1' else False
+        self.handler.image_has_auto_rebuild_tag = MagicMock(return_value=True)
+        get_build = self.patcher.patch("freshmaker.kojiservice.KojiService.get_build")
+        get_build.side_effect = lambda x: builds[x]
+
+        now = datetime(year=2020, month=12, day=25, hour=0, minute=0, second=0)
+        with freezegun.freeze_time(now):
+            bundles_to_rebuild = self.handler._handle_bundle_rebuild(db_event)
 
         self.assertNotEqual(db_event.state, EventState.SKIPPED.value)
         get_build.assert_has_calls([call("bundle1_nvr-1-1"), call("bundle2_nvr-1-1")], any_order=True)
@@ -285,8 +464,8 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_csv_updates")
     @patch("freshmaker.kojiservice.KojiService.get_build")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_pullspecs_mapping")
-    def test_handle_manual_rebuild(self, get_pullspecs_mapping, get_build,
-                                   get_csv_updates):
+    def test_handle_release_driver_rebuild(self, get_pullspecs_mapping, get_build,
+                                           get_csv_updates):
 
         get_pullspecs_mapping.return_value = {
             "old_pullspec": "new_pullspec",
@@ -338,7 +517,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             }],
         }
 
-        event = ManualBundleRebuild(
+        event = ManualBundleRebuild.from_release_driver_request(
             "test_msg_id",
             container_images=["container_image_1_nvr", "container_image_2_nvr"],
             bundle_images=[])
@@ -358,7 +537,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         get_csv_updates.return_value = {"update": "csv_update_placeholder"}
         db.session.commit()
 
-        bundles_to_rebuild = self.handler._handle_manual_rebuild(db_event)
+        bundles_to_rebuild = self.handler._handle_release_driver_rebuild(db_event)
 
         expected_bundles = [
             {
@@ -397,7 +576,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             any_order=True)
 
     def test_get_pullspecs_mapping(self):
-        event = ManualBundleRebuild(
+        event = ManualBundleRebuild.from_release_driver_request(
             "test_msg_id",
             container_images=[],
             bundle_images=["bundle_image_1", "bundle_image_2"])


### PR DESCRIPTION
Now when there is need in retriggering bundle build due to fail or
something else, there is functionality for it.

Note: it's implemented only to retrigger automatic rebuilds, it's not
for manual rebuild event triggered by BOTAS.

JIRA: CWFHEALTH-603

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>