### PR TITLE
Update comment and doc for `build_id`

### DIFF
--- a/docs/api_v1.rst
+++ b/docs/api_v1.rst
@@ -179,7 +179,7 @@ The Freshmaker Artifact Build is always represented in the API request as JSON, 
 .. _build_build_id:
 
 *build_id* - ``(number)``
-    The ID of Artifact Build.
+    The ID of Artifact Build. For container images (the only supported artifact at this moment), it's task id in koji/brew build system.
 
 .. _build_dep_on:
 

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -548,10 +548,11 @@ class ArtifactBuild(FreshmakerBase):
     event_id = db.Column(db.Integer, db.ForeignKey('events.id'))
     event = relationship("Event", back_populates="builds")
 
-    # Id of corresponding real build in external build system. Currently, it
-    # could be ID of a build in MBS or Koji, maybe others in the future.
-    # build_id may be NULL, which means this build has not been built in
-    # external build system.
+    # Id of corresponding real build in external build system.
+    # For container images (the only supported artifact at this moment),
+    # this is the id of image build task in koji/brew. It could be NULL,
+    # which means the image build task has not been submitted to build
+    # system (koji/brew), or freshmaker failed to submit the build task.
     build_id = db.Column(db.Integer)
 
     # Build args in json format.


### PR DESCRIPTION
For container images, `build_id` is actually the build task id,
the name is easy to make some confusions, update doc and comment
for this.

See #99 