### PR TITLE
further updates to build_id docs

### DIFF
--- a/docs/api_v1.rst
+++ b/docs/api_v1.rst
@@ -179,7 +179,7 @@ The Freshmaker Artifact Build is always represented in the API request as JSON, 
 .. _build_build_id:
 
 *build_id* - ``(number)``
-    The ID of Artifact Build. For container images (the only supported artifact at this moment), it's task id in koji/brew build system.
+    The ID of Artifact Build. For container images (the only supported artifact at this moment), this is the Koji (or Brew) buildContainer task ID. If this field is null, Freshmaker did not submit a buildContainer task (due to some other failure), or Koji failed to return a task ID for some reason.
 
 .. _build_dep_on:
 

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -550,9 +550,10 @@ class ArtifactBuild(FreshmakerBase):
 
     # Id of corresponding real build in external build system.
     # For container images (the only supported artifact at this moment),
-    # this is the id of image build task in koji/brew. It could be NULL,
-    # which means the image build task has not been submitted to build
-    # system (koji/brew), or freshmaker failed to submit the build task.
+    # this is the Koji (or Brew) buildContainer task ID. It could be NULL,
+    # which means Freshmaker did not submit a buildContainer task (due to
+    # some other failure), or Koji failed to return a task ID for some
+    # reason.
     build_id = db.Column(db.Integer)
 
     # Build args in json format.


### PR DESCRIPTION
Explain that the Koji task that we track in `build_id` is a buildContainer task.

Publicly document that a null `build_id` implies that Freshmaker did not submit the task *or* that Koji did not give a task ID back to Freshmaker.