### PR TITLE
Fix bundle manual rebuild

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -487,8 +487,15 @@ class ManualBundleRebuild(BaseEvent):
     def from_release_driver_request(cls, msg_id, container_images, bundle_images,
                                     metadata=None, requester=None, **kwargs):
         event = cls(msg_id, **kwargs)
+        event.advisory = None
         event.container_images = container_images
         event.bundle_images = bundle_images
         event.metadata = metadata
         event.requester = requester
         return event
+
+    @property
+    def search_key(self):
+        if self.advisory:
+            return self.advisory.errata_id
+        return self.msg_id

--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -475,23 +475,31 @@ class ManualBundleRebuild(BaseEvent):
     @classmethod
     def from_manual_rebuild_request(cls, msg_id, advisory,
                                     freshmaker_event_id=None,
-                                    container_images=[], requester=None, **kwargs):
+                                    container_images=[],
+                                    requester=None,
+                                    requester_metadata_json=None,
+                                    **kwargs):
         event = cls(msg_id, **kwargs)
         event.advisory = advisory
         event.freshmaker_event_id = freshmaker_event_id
         event.container_images = container_images
         event.requester = requester
+        event.requester_metadata_json = requester_metadata_json
         return event
 
     @classmethod
-    def from_release_driver_request(cls, msg_id, container_images, bundle_images,
-                                    metadata=None, requester=None, **kwargs):
+    def from_release_driver_request(cls, msg_id,
+                                    container_images,
+                                    bundle_images,
+                                    requester=None,
+                                    requester_metadata_json=None,
+                                    **kwargs):
         event = cls(msg_id, **kwargs)
         event.advisory = None
         event.container_images = container_images
         event.bundle_images = bundle_images
-        event.metadata = metadata
         event.requester = requester
+        event.requester_metadata_json = requester_metadata_json
         return event
 
     @property

--- a/freshmaker/parsers/internal/manual_rebuild.py
+++ b/freshmaker/parsers/internal/manual_rebuild.py
@@ -60,6 +60,7 @@ class FreshmakerManualRebuildParser(BaseParser):
                     data.get('freshmaker_event_id', None),
                     data.get('container_images', []),
                     requester=data.get('requester', None),
+                    requester_metadata_json=data.get('requester_metadata_json', None),
                     dry_run=dry_run)
             else:
                 event = ManualRebuildWithAdvisoryEvent(
@@ -73,10 +74,13 @@ class FreshmakerManualRebuildParser(BaseParser):
         # Retriggered rebuild of bundles by Release Driver
         else:
             event = ManualBundleRebuild.from_release_driver_request(
-                msg_id, data.get('container_images', []), data.get('bundle_images'),
-                data.get('metadata', None), dry_run=dry_run,
-                requester=data.get('requester', None))
-
+                msg_id,
+                data.get('container_images', []),
+                data.get('bundle_images'),
+                requester=data.get('requester', None),
+                requester_metadata_json=data.get('requester_metadata_json', None),
+                dry_run=dry_run,
+            )
         return event
 
     def parse(self, topic, msg):

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -520,8 +520,13 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         event = ManualBundleRebuild.from_release_driver_request(
             "test_msg_id",
             container_images=["container_image_1_nvr", "container_image_2_nvr"],
-            bundle_images=[])
+            bundle_images=[],
+            requester="release-driver",
+            requester_metadata_json={"rebuild_queue": []})
+
         db_event = Event.get_or_create_from_event(db.session, event)
+        self.assertEqual(json.loads(db_event.requester_metadata), {"rebuild_queue": []})
+
         self.handler.event = event
         get_build.side_effect = lambda nvr: build_by_nvr[nvr]
         build = ArtifactBuild.create(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -876,7 +876,7 @@ class TestManualTriggerRebuild(ViewBaseTest):
                           'requested_rebuilds': ['container_image'],
                           'requester': 'root',
                           'requester_metadata': {},
-                          'search_key': 'manual_rebuild_111',
+                          'search_key': '123',
                           'state': 0,
                           'state_name': 'INITIALIZED',
                           'state_reason': None,


### PR DESCRIPTION
1. return advisory id as search_key of manual bundle rebuild when it exists
2. store requester_metadata_json data in database