### PR TITLE
Add timeouts to requests in Freshmaker

### DIFF
--- a/contrib/freshmaker-cli
+++ b/contrib/freshmaker-cli
@@ -33,6 +33,7 @@ from datetime import date, timedelta, datetime
 import requests
 from requests_kerberos import HTTPKerberosAuth
 from tabulate import tabulate
+from freshmaker import conf
 
 # Disable InsecureRequestWarning
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -181,7 +182,7 @@ def _get_freshmaker_items(url, params, limit=None):
     ret_items = []
     while True:
         print("Getting messages from Freshmaker, page", params["page"])
-        r = requests.get(url, verify=False, params=params)
+        r = requests.get(url, verify=False, params=params, timeout=conf.requests_timeout)
         ret = r.json()
         items = ret["items"]
         if not items:
@@ -238,7 +239,7 @@ def get_freshmaker_events_by_ids(api_url, ids):
         print("Getting Freshmaker event id", i)
         url = '%s/api/1/events/%s' % (api_url, str(i))
 
-        r = requests.get(url, verify=False)
+        r = requests.get(url, verify=False, timeout=conf.requests_timeout)
         ret = r.json()
         if not "error" in ret:
             events += [ret]
@@ -265,7 +266,7 @@ def get_advisories_from_errata(errata_url, days=7):
     date_from = date.today() - timedelta(days)
     while True:
         print("Getting advisories from  Errata page", page)
-        r = requests.get(errata_url, auth=krb_auth, timeout=30, params={page: page})
+        r = requests.get(errata_url, auth=krb_auth, timeout=conf.requests_timeout, params={page: page})
         r.raise_for_status()
         data = r.json()
         if not data:
@@ -284,7 +285,7 @@ def get_errata_advisories_ignored_by_freshmaker(api_url, advisories):
     events = []
     for advisory in advisories:
         url = urllib.parse.urljoin(api_url, f'/api/1/events/?search_key={advisory}')
-        r = requests.get(url, timeout=30)
+        r = requests.get(url, timeout=conf.requests_timeout)
         r.raise_for_status()
         ret = r.json()
         if not ret["items"]:

--- a/contrib/generate_report.py
+++ b/contrib/generate_report.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import argparse
 import requests
 from requests_kerberos import HTTPKerberosAuth
+from requests import conf
 
 TEMPLATE = """
 On {freshmaker_date}, Freshmaker rebuilt {original_nvr} container image [1] as a result of Important/Critical RHSA advisory [2].
@@ -27,7 +28,7 @@ FRESHMAKER_URL = 'https://freshmaker.engineering.redhat.com/api/1/'
 
 def get_advisory(errata_id):
     krb_auth = HTTPKerberosAuth()
-    r = requests.get(ERRATA_URL + "erratum/%s" % str(errata_id), auth=krb_auth)
+    r = requests.get(ERRATA_URL + "erratum/%s" % str(errata_id), auth=krb_auth, timeout=conf.requests_timeout)
     r.raise_for_status()
     data = r.json()
     return data["errata"].values()[0]
@@ -35,7 +36,7 @@ def get_advisory(errata_id):
 
 def get_freshmaker_build(search_key, original_nvr):
     url = FRESHMAKER_URL + "events/?search_key=%s" % search_key
-    r = requests.get(url)
+    r = requests.get(url, timeout=conf.requests_timeout)
     r.raise_for_status()
     data = r.json()
     for build in data["items"][0]["builds"]:

--- a/contrib/get_freshmaker_stats.py
+++ b/contrib/get_freshmaker_stats.py
@@ -10,6 +10,7 @@ import sys
 import requests
 from requests_kerberos import HTTPKerberosAuth
 from tabulate import tabulate
+from freshmaker import conf
 
 from lightblue.service import LightBlueService
 from lightblue.entity import LightBlueEntity
@@ -88,7 +89,7 @@ def get_image_advisories_from_image_nvrs(grouped_images):
             if nvr in nvr_to_image_erratum:
                 continue
 
-            r = requests.get(ERRATA_URL + "build/" + nvr, auth=krb_auth)
+            r = requests.get(ERRATA_URL + "build/" + nvr, auth=krb_auth, timeout=conf.requests_timeout)
             r.raise_for_status()
             data = r.json()
             if not data['all_errata']:
@@ -102,7 +103,7 @@ def get_image_advisories_from_image_nvrs(grouped_images):
             msg = "[%i/%i]: %s" % (nvrs_checks, nvrs_to_check, errata_name)
             sys.stdout.write(msg + chr(8) * len(msg))
             sys.stdout.flush()
-            r = requests.get(ERRATA_URL + "erratum/%s/builds" % (errata_name), auth=krb_auth)
+            r = requests.get(ERRATA_URL + "erratum/%s/builds" % (errata_name), auth=krb_auth, timeout=conf.requests_timeout)
             r.raise_for_status()
             data = r.json()
             for builds_dict in data.values():
@@ -114,13 +115,13 @@ def get_image_advisories_from_image_nvrs(grouped_images):
 
 def is_content_advisory_rebuilt_by_freshmaker(errata_name):
     krb_auth = HTTPKerberosAuth()
-    r = requests.get(ERRATA_URL + "erratum/" + errata_name, auth=krb_auth)
+    r = requests.get(ERRATA_URL + "erratum/" + errata_name, auth=krb_auth, timeout=conf.requests_timeout)
     r.raise_for_status()
     data = r.json()
     errata_id = str(data["content"]["content"]["errata_id"])
 
     url = FRESHMAKER_URL + "events/?search_key=%s&per_page=1" % errata_id
-    r = requests.get(url)
+    r = requests.get(url, timeout=conf.requests_timeout)
     r.raise_for_status()
     data = r.json()
     if data["meta"]["total"] == 0:

--- a/freshmaker/auth.py
+++ b/freshmaker/auth.py
@@ -219,7 +219,7 @@ def get_user_info(token):
     headers = {
         'authorization': 'Bearer {0}'.format(token)
     }
-    r = requests.get(conf.auth_openidc_userinfo_uri, headers=headers)
+    r = requests.get(conf.auth_openidc_userinfo_uri, headers=headers, timeout=conf.requests_timeout)
     if r.status_code != 200:
         raise Unauthorized(
             'Cannot get user information from {0} endpoint.'.format(

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -151,6 +151,10 @@ class Config(object):
             'type': int,
             'default': 120,
             'desc': 'Global network timeout for read/write operations, in seconds.'},
+        'requests_timeout': {
+            'type': int,
+            'default': 120,
+            'desc': ' Global timeout for HTTP requests in Freshmaker.'},
         'net_retry_interval': {
             'type': int,
             'default': 30,

--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -163,7 +163,7 @@ class Errata(object):
             r = requests.get(
                 *args,
                 auth=HTTPKerberosAuth(principal=conf.krb_auth_principal),
-                **kwargs)
+                **kwargs, timeout=conf.requests_timeout)
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
             if e.response is not None and e.response.status_code == 401:

--- a/freshmaker/handlers/bob/rebuild_images_on_image_advisory_change.py
+++ b/freshmaker/handlers/bob/rebuild_images_on_image_advisory_change.py
@@ -120,7 +120,7 @@ class RebuildImagesOnImageAdvisoryChange(ContainerBuildHandler):
                 self.log_info("DRY RUN: Skipping request to Bob.")
                 continue
 
-            r = requests.get(bob_url, headers=headers)
+            r = requests.get(bob_url, headers=headers, timeout=conf.requests_timeout)
             r.raise_for_status()
             resp = r.json()
             self.log_info("Response: %r", resp)

--- a/freshmaker/kojiservice.py
+++ b/freshmaker/kojiservice.py
@@ -282,11 +282,11 @@ class KojiService(object):
         cg_metadata_url = None
         try:
             cg_metadata_url = self.get_cg_metadata_url(buildinfo)
-            resp = requests.get(cg_metadata_url)
+            resp = requests.get(cg_metadata_url, timeout=conf.requests_timeout)
             # url is redirected
             if resp.history:
                 cg_metadata_url = resp.url
-            return requests.get(cg_metadata_url).json()
+            return requests.get(cg_metadata_url, timeout=conf.requests_timeout).json()
         except requests.ConnectionError:
             raise
         except Exception as e:

--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -581,9 +581,9 @@ class LightBlue(object):
                 record_mode=conf.vcrpy_mode,
             )
             with my_vcr.use_cassette(f'{self.event_id}.yml'):
-                response = requests.post(entity_url, **request_kwargs)
+                response = requests.post(entity_url, **request_kwargs, timeout=conf.requests_timeout)
         else:
-            response = requests.post(entity_url, **request_kwargs)
+            response = requests.post(entity_url, **request_kwargs, timeout=max(600, conf.requests_timeout * 5))
 
         status_code = response.status_code
 

--- a/freshmaker/pulp.py
+++ b/freshmaker/pulp.py
@@ -25,6 +25,7 @@ import json
 import requests
 
 from freshmaker.utils import retry
+from freshmaker import conf
 
 
 class Pulp(object):
@@ -40,7 +41,8 @@ class Pulp(object):
         r = requests.post(
             '{0}{1}'.format(self.rest_api_root, endpoint.lstrip('/')),
             post_data,
-            auth=(self.username, self.password))
+            auth=(self.username, self.password),
+            timeout=conf.requests_timeout)
         r.raise_for_status()
         return r.json()
 
@@ -48,7 +50,8 @@ class Pulp(object):
         r = requests.get(
             '{0}{1}'.format(self.rest_api_root, endpoint.lstrip('/')),
             params=kwargs,
-            auth=(self.username, self.password))
+            auth=(self.username, self.password),
+            timeout=conf.requests_timeout)
         r.raise_for_status()
         return r.json()
 

--- a/tests/handlers/bob/test_rebuild_images_on_image_advisory_change.py
+++ b/tests/handlers/bob/test_rebuild_images_on_image_advisory_change.py
@@ -27,7 +27,7 @@ from freshmaker.errata import ErrataAdvisory
 from freshmaker.events import (ErrataAdvisoryStateChangedEvent,
                                ManualRebuildWithAdvisoryEvent)
 from freshmaker.handlers.bob import RebuildImagesOnImageAdvisoryChange
-from freshmaker import models, db
+from freshmaker import models, db, conf
 from tests import helpers
 
 
@@ -114,10 +114,12 @@ class RebuildImagesOnImageAdvisoryChangeTest(helpers.ModelsTestCase):
         get_docker_repository_name.assert_any_call("foo-526")
         requests_get.assert_any_call(
             'http://localhost/update_children/scl/foo-526',
-            headers={'Authorization': 'Bearer x'})
+            headers={'Authorization': 'Bearer x'},
+            timeout=conf.requests_timeout)
         requests_get.assert_any_call(
             'http://localhost/update_children/scl/bar-526',
-            headers={'Authorization': 'Bearer x'})
+            headers={'Authorization': 'Bearer x'},
+            timeout=conf.requests_timeout)
 
         db.session.refresh(self.db_event)
 

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -29,6 +29,7 @@ from unittest import mock
 from unittest.mock import call, patch, Mock
 
 import freshmaker
+from freshmaker import conf
 
 from freshmaker.lightblue import ContainerImage, ContainerRepository, ExtraRepoNotConfiguredError
 from freshmaker.lightblue import LightBlue, LightBlueRequestError, LightBlueSystemError
@@ -878,7 +879,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             data=json.dumps(fake_request),
             verify=lb.verify_ssl,
             cert=(self.fake_cert_file, self.fake_private_key),
-            headers={'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'},
+            timeout=max(600, conf.requests_timeout * 5)
         )
         self.assertEqual(2, len(images))
 
@@ -950,7 +952,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             data=json.dumps(fake_request),
             verify=lb.verify_ssl,
             cert=(self.fake_cert_file, self.fake_private_key),
-            headers={'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'},
+            timeout=max(600, conf.requests_timeout * 5)
         )
         self.assertEqual(1, len(images))
         # Verify update_multi_arch is first called with the second image,
@@ -1023,7 +1026,8 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             data=json.dumps(fake_request),
             verify=lb.verify_ssl,
             cert=(self.fake_cert_file, self.fake_private_key),
-            headers={'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'},
+            timeout=max(600, conf.requests_timeout * 5)
         )
 
         self.assertEqual(2, len(repos))

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 from requests import exceptions
 
 from freshmaker.pulp import Pulp
+from freshmaker import conf
 from tests import helpers
 
 
@@ -94,7 +95,8 @@ class TestPulp(helpers.FreshmakerTestCase):
                     'fields': ['notes'],
                 }
             }),
-            auth=(self.username, self.password))
+            auth=(self.username, self.password),
+            timeout=conf.requests_timeout)
 
         self.assertEqual(
             ['rhel-7-workstation-rpms',
@@ -155,7 +157,8 @@ class TestPulp(helpers.FreshmakerTestCase):
                     'fields': ['notes'],
                 }
             }),
-            auth=(self.username, self.password))
+            auth=(self.username, self.password),
+            timeout=conf.requests_timeout)
 
         self.assertEqual(['rhel-7-workstation-rpms', 'rhel-7-desktop-rpms'],
                          content_sets)
@@ -178,7 +181,8 @@ class TestPulp(helpers.FreshmakerTestCase):
         get.assert_called_once_with(
             '{}pulp/api/v2/repositories/foo-526/'.format(self.server_url),
             params={"distributors": True},
-            auth=(self.username, self.password))
+            auth=(self.username, self.password),
+            timeout=conf.requests_timeout)
 
         self.assertEqual(repo_name, "scl/foo-526")
 


### PR DESCRIPTION
Add configurable timeout to requests to avoid FM from hanging.