### PR TITLE
Remove odcs composes added by freshmaker in original image

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -36,7 +36,7 @@ from itertools import groupby
 
 from freshmaker import log, conf
 from freshmaker.kojiservice import koji_service
-from freshmaker.odcsclient import create_odcs_client
+from freshmaker.models import ArtifactBuild
 from freshmaker.utils import sorted_by_nvr, is_pkg_modular
 import koji
 
@@ -149,11 +149,6 @@ class ContainerImage(dict):
         if arch and rpm_manifest:
             image['multi_arch_rpm_manifest'][arch] = rpm_manifest
 
-        image['multi_arch_content_sets'] = {}
-        content_sets = data.get('content_sets')
-        if arch and content_sets:
-            image['multi_arch_content_sets'][arch] = content_sets
-
         return image
 
     def __hash__(self):
@@ -194,10 +189,6 @@ class ContainerImage(dict):
         if image_rpm_manifest:
             self['multi_arch_rpm_manifest'][image_arch] = image_rpm_manifest
 
-        image_content_sets = image.get('content_sets')
-        if image_content_sets:
-            self['multi_arch_content_sets'][image_arch] = image_content_sets
-
     @staticmethod
     def _get_default_additional_data():
         return {
@@ -207,9 +198,7 @@ class ContainerImage(dict):
             "git_branch": None,
             "error": None,
             "arches": None,
-            "odcs_compose_ids": None,
             "parent_image_builds": None,
-            "generate_pulp_repos": True,
         }
 
     @classmethod
@@ -251,11 +240,7 @@ class ContainerImage(dict):
                            f'is not specified in the Freshmaker configuration.')
                     raise ExtraRepoNotConfiguredError(msg)
 
-            # Get the list of ODCS composes used to build the image.
             extra_image = build.get("extra", {}).get("image", {})
-            if extra_image.get("odcs", {}).get("compose_ids"):
-                data["odcs_compose_ids"] = extra_image["odcs"]["compose_ids"]
-
             data["parent_build_id"] = extra_image.get("parent_build_id")
             data["parent_image_builds"] = extra_image.get("parent_image_builds")
 
@@ -334,36 +319,37 @@ class ContainerImage(dict):
 
         self.update(data)
 
-    def resolve_compose_sources(self):
+    def resolve_original_odcs_compose_ids(self):
         """
-        Get source values of ODCS composes used in image build task
+        Resolve the ODCS compose ids used in most original image
 
-        Populate image["compose_sources"] with a set of these values
+        Gets the ODCS compose ids by excluding the composes added by
+        freshmaker, and sets the "original_odcs_compose_ids" of this image
         """
-        compose_sources = self.get("compose_sources", None)
-        # This has been populated?
-        if compose_sources is not None:
+        # This has been populated, skip.
+        if self.get("original_odcs_compose_ids") is not None:
             return
 
-        odcs_client = create_odcs_client()
-        self["compose_sources"] = set()
-        compose_ids = self.get("odcs_compose_ids")
-        if not compose_ids:
-            return
+        self["generate_pulp_repos"] = True
+        self["original_odcs_compose_ids"] = []
+        # If this image was built by freshmaker, query database recursively to
+        # get the NVR of most original image which was not built by freshmaker
+        most_original_nvr = ArtifactBuild.get_most_original_nvr(self.nvr)
+        if most_original_nvr is None:
+            most_original_nvr = self.nvr
 
-        for compose_id in compose_ids:
-            # Get odcs compose source value from odcs server
-            compose = odcs_client.get_compose(compose_id)
-            source = compose.get("source", "")
-            # NOTE: source is converted to list and then sorted before
-            # convert it back to string, so it can be easily compared
-            # later when check whether a compose source already exists
-            source = " ".join(sorted(source.split()))
-            if source:
-                self["compose_sources"].add(source)
+        compose_ids = []
+        with koji_service(conf.koji_profile, log, dry_run=conf.dry_run, login=False) as session:
+            try:
+                compose_ids = session.get_odcs_compose_ids(most_original_nvr)
+            except Exception as e:
+                self["error"] = str(e)
+                log.error("Failed to resolve original odcs compose ids for %s", self.nvr)
+                return
 
-        log.info("Container image %s uses following compose sources: %r",
-                 self.nvr, self["compose_sources"])
+        self["original_odcs_compose_ids"] = compose_ids
+        log.info("Original ODCS compose ids of %s: %r (from %s)",
+                 self.nvr, self["original_odcs_compose_ids"], most_original_nvr)
 
     def resolve_content_sets(self, lb_instance, children=None):
         """
@@ -443,7 +429,7 @@ class ContainerImage(dict):
         """
         try:
             self.resolve_commit()
-            self.resolve_compose_sources()
+            self.resolve_original_odcs_compose_ids()
             self.resolve_content_sets(lb_instance, children)
             self.resolve_published(lb_instance)
         except Exception as e:

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -626,6 +626,20 @@ class ArtifactBuild(FreshmakerBase):
             return 0
         return build.build_id
 
+    @classmethod
+    def get_most_original_nvr(cls, nvr):
+        """
+        Get original NVR recursively until reach the one which was not built by freshmaker
+
+        Return the NVR of most original image
+        """
+        original_nvr = None
+        build = db.session.query(ArtifactBuild).filter(cls.rebuilt_nvr == nvr).first()
+        while build:
+            original_nvr = build.original_nvr
+            build = db.session.query(ArtifactBuild).filter(cls.rebuilt_nvr == original_nvr).first()
+        return original_nvr
+
     @property
     def bundle_pullspec_overrides(self):
         """Return the Python representation of the JSON bundle_pullspec_overrides."""

--- a/freshmaker/odcsclient.py
+++ b/freshmaker/odcsclient.py
@@ -197,6 +197,15 @@ class FreshmakerODCSClient(object):
                         "latest is %r), skipping this tag",
                         nvr, tag, latest_build[0]['nvr'])
 
+    def get_compose(self, compose_id):
+        """ Get compose info from ODCS
+
+        :param int compose_id: id of compose
+        :return: a dict of compose info
+        :rtype: dict
+        """
+        return create_odcs_client().get_compose(compose_id)
+
     def prepare_yum_repos_for_rebuilds(self, db_event):
         repo_urls = []
         db_composes = []

--- a/tests/handlers/koji/test_rebuild_images_on_async_manual_build.py
+++ b/tests/handlers/koji/test_rebuild_images_on_async_manual_build.py
@@ -64,6 +64,8 @@ class TestRebuildImagesOnAsyncManualBuild(helpers.ModelsTestCase):
         self.mock_start_to_build_images = self.patcher.patch('start_to_build_images')
         self.mock_get_image_builds_in_first_batch = self.patcher.patch(
             'freshmaker.models.Event.get_image_builds_in_first_batch')
+        self.mock_get_most_original_nvr = self.patcher.patch(
+            'freshmaker.models.ArtifactBuild.get_most_original_nvr')
 
         # Structure of the images used for testing:
         #       image_0

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -78,9 +78,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_a_content_set_1', 'image_a_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_a_content_set_1', 'image_a_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-a-1.0-2',
@@ -93,8 +90,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         self.image_b = ContainerImage({
@@ -103,9 +99,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_b_content_set_1', 'image_b_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_b_content_set_1', 'image_b_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-b-1.0-1'
@@ -118,8 +111,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         self.image_c = ContainerImage({
@@ -128,9 +120,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_c_content_set_1', 'image_d_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_c_content_set_1', 'image_c_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-c-0.2-9',
@@ -144,8 +133,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         self.image_d = ContainerImage({
@@ -154,9 +142,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_d_content_set_1', 'image_d_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_d_content_set_1', 'image_d_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-d-2.14-1',
@@ -170,8 +155,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         self.image_e = ContainerImage({
@@ -180,9 +164,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_e_content_set_1', 'image_e_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_e_content_set_1', 'image_e_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-e-1.0-1',
@@ -196,8 +177,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         self.image_f = ContainerImage({
@@ -206,9 +186,6 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
             'target': 'docker-container-candidate',
             'git_branch': 'rhel-7.4',
             'content_sets': ['image_f_content_set_1', 'image_f_content_set_2'],
-            'multi_arch_content_sets': {
-                'x86_64': ['image_f_content_set_1', 'image_f_content_set_2']
-            },
             "arches": "x86_64",
             'brew': {
                 'build': 'image-f-0.2-1',
@@ -222,8 +199,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "odcs_compose_ids": None,
-            "compose_sources": set(),
+            "original_odcs_compose_ids": [],
             "published": False,
         })
         # For simplicify, mocking _find_images_to_rebuild to just return one
@@ -849,11 +825,9 @@ class TestBatches(helpers.ModelsTestCase):
             'git_branch': 'mybranch',
             "error": error,
             "content_sets": ["first-content-set"],
-            "multi_arch_content_sets": {'x86_64': ["first-content-set"]},
             "generate_pulp_repos": True,
             "arches": "x86_64",
-            "odcs_compose_ids": [10, 11],
-            "compose_sources": {"first-content-set"},
+            "original_odcs_compose_ids": [10, 11],
             "published": False,
         }
         d.update(kwargs)
@@ -873,7 +847,7 @@ class TestBatches(helpers.ModelsTestCase):
             'state_name': 'done'
         } for compose_id in range(1, 9)]
         odcs.new_compose.side_effect = composes
-        odcs.get_compose.side_effect = composes
+        odcs.get_compose.return_value = {}
 
         # Creates following tree:
         # shared_parent
@@ -1055,7 +1029,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 },
                 "parent": None,
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "123456789",
                 "target": "target-candidate",
@@ -1063,8 +1036,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1101,7 +1073,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                     "error": None
                 }),
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "987654321",
                 "target": "target-candidate",
@@ -1109,8 +1080,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1157,7 +1127,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": False,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": True,
             })]
         ]
@@ -1190,7 +1160,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 },
                 "parent": None,
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "123456789",
                 "target": "target-candidate",
@@ -1198,8 +1167,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": False,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1232,7 +1200,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 },
                 "parent": None,
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "123456789",
                 "target": "target-candidate",
@@ -1240,8 +1207,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "arches": "x86_64",
                 "generate_pulp_repos": True,
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1278,7 +1244,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                     "error": None
                 }),
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "987654321",
                 "target": "target-candidate",
@@ -1286,8 +1251,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "arches": "x86_64",
                 "generate_pulp_repos": True,
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1313,7 +1277,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
             call(parent_build, ["content-set-1"])
         ])
 
-    def test_do_not_generate_duplicate_pulp_compose(self):
+    @patch('freshmaker.odcsclient.create_odcs_client')
+    def test_do_not_generate_duplicate_pulp_compose(self, create_odcs_client):
         batches = [
             [ContainerImage({
                 "brew": {
@@ -1329,7 +1294,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 },
                 "parent": None,
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "123456789",
                 "target": "target-candidate",
@@ -1337,11 +1301,15 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "arches": "x86_64",
                 "generate_pulp_repos": True,
-                "odcs_compose_ids": None,
-                "compose_sources": {"content-set-1"},
+                "original_odcs_compose_ids": [123],
                 "published": False,
             })]
         ]
+        odcs = create_odcs_client.return_value
+        odcs.get_compose.return_value = {
+            "source_type": 4,
+            "source": "content-set-1"
+        }
 
         handler = RebuildImagesOnRPMAdvisoryChange()
         handler._record_batches(batches, self.mock_event)
@@ -1374,7 +1342,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occurs while getting this image.",
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1411,7 +1379,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occurs while getting this image.",
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1448,7 +1416,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured.",
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1491,7 +1459,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured too.",
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1532,7 +1500,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured.",
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
+                "original_odcs_compose_ids": [],
                 "published": False,
             })],
         ]
@@ -1563,7 +1531,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 },
                 "parent": None,
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "123456789",
                 "target": "target-candidate",
@@ -1571,8 +1538,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1609,7 +1575,6 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                     "error": None
                 }),
                 "content_sets": ["content-set-1"],
-                "multi_arch_content_sets": {"x86_64": ["content-set-1"]},
                 "repository": "repo-1",
                 "commit": "987654321",
                 "target": "target-candidate",
@@ -1617,8 +1582,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "odcs_compose_ids": None,
-                "compose_sources": set(),
+                "original_odcs_compose_ids": [],
                 "published": False,
             })]
         ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,6 +209,25 @@ class TestModels(helpers.ModelsTestCase):
             'depends_on_events': [],
         })
 
+    def test_get_most_original_nvr(self):
+        event = Event.create(db.session, "test_msg_id", "test", events.TestingEvent)
+        ArtifactBuild.create(
+            db.session, event, "ubi", "image", 1234,
+            original_nvr="ubi-2-1", rebuilt_nvr="ubi-2-1.1580000001"
+        )
+        ArtifactBuild.create(
+            db.session, event, "ubi", "image", 1235,
+            original_nvr="ubi-2-1.1580000001", rebuilt_nvr="ubi-2-1.1580000002"
+        )
+        ArtifactBuild.create(
+            db.session, event, "ubi", "image", 1236,
+            original_nvr="ubi-2-1.1580000002", rebuilt_nvr="ubi-2-1.1580000003"
+        )
+        db.session.commit()
+        db.session.expire_all()
+        nvr = ArtifactBuild.get_most_original_nvr("ubi-2-1.1580000003")
+        self.assertEqual(nvr, "ubi-2-1")
+
 
 class TestFindDependentEvents(helpers.ModelsTestCase):
     """Test Event.find_dependent_events"""


### PR DESCRIPTION
When an original image was built by freshmaker, there could be some odcs
composes added by freshmaker in build task, so if there is an image was
rebuilt by freshmaker for several times, the latest original image could
have some duplicated odcs composes in build task. For example:

    1. image-2.1 was built and it has compose 101.
    2. image-2-1 was rebuilt by freshmaker, new compose 102 added, new
       NVR is image-2-1.0001, composes 101 and 102 are enabled in build
       task.
    3. image-2-1.0001 was rebuilt by freshmaker again, new compose 103
       added, new NVR is image-2-1.0002, its build task has composes:
       101, 102 and 103.

Then if freshmaker needs to rebuild image-2-1.0002, it will submit the
build task with composes: 101, 102 and 103. After 4694dda, freshmaker
doesn't add new composes which already exist, but it can't remove the
duplicated composes from original image (image-2-1.0002 in this case).

With this change, freshmaker will only keep the composes from most
original image (in this case it's compose 101 from image-2.1), thus
composes added by freshmaker in original image (image-2-1.0002) are
removed.

JIRA: CWFHEALTH-689