### PR TITLE
Fix get_latest_bundles to return unique bundles

### DIFF
--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -181,15 +181,14 @@ class Pyxis(object):
                     )
                     return False
 
-            # Discard any bundles with invalid semantic versions since Freshmaker
-            # would not be able to modify the version appropriately.
-            bundle_list = [
-                bundle
-                for bundle in self._pagination('operators/bundles', request_params)
-                if _isvalid(bundle["version_original"], bundle["csv_name"])
-            ]
-
-            latest_bundles.extend(bundle_list)
+            for bundle in self._pagination('operators/bundles', request_params):
+                # Discard any bundles with invalid semantic versions since Freshmaker
+                # would not be able to modify the version appropriately.
+                if not _isvalid(bundle["version_original"], bundle["csv_name"]):
+                    continue
+                if bundle in latest_bundles:
+                    continue
+                latest_bundles.append(bundle)
 
         return latest_bundles
 

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -452,6 +452,15 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
         ])
 
     @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_get_latest_bundles_returns_unique_bundles(self, page):
+        page_copy = self.copy_call_args(page)
+        # self.bundles[0] exists in two indices
+        page_copy.side_effect = [self.bundles[:3] + self.bundles[:1], []]
+
+        out = self.px.get_latest_bundles(self.indices)
+        self.assertEqual(out, self.bundles[:3])
+
+    @patch('freshmaker.pyxis.Pyxis._pagination')
     def test_get_manifest_list_digest_by_nvr(self, page):
         page.return_value = self.images
         digest = self.px.get_manifest_list_digest_by_nvr('s2i-1-2')


### PR DESCRIPTION
A bundle can exists in multiple index images, get_latest_bundles should
return unique bundles, otherwise the botas handler can rebuild a bundle
for multiple times.

JIRA: CWFHEALTH-695