### PR TITLE
Skip rebuilt images in old events of advisory by default

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -1554,7 +1554,7 @@ class LightBlue(object):
     def find_images_to_rebuild(
             self, rpm_nvrs, content_sets, published=True,
             release_categories=conf.lightblue_release_categories,
-            filter_fnc=None, leaf_container_images=None):
+            filter_fnc=None, leaf_container_images=None, skip_nvrs=None):
         """
         Find images to rebuild through image build layers
 
@@ -1581,10 +1581,15 @@ class LightBlue(object):
             consider for the rebuild. If not set, all images found in
             Lightblue will be considered for rebuild. Note that `published`
             is not respected when `leaf_container_images` are used.
+        :param list skip_nvrs: List of NVRs of images to be skipped.
         """
         images = self.find_images_with_packages_from_content_set(
             rpm_nvrs, content_sets, filter_fnc, published,
             release_categories, leaf_container_images=leaf_container_images)
+
+        # Not skip images when rebuild images are requested explicitly
+        if skip_nvrs and not leaf_container_images:
+            images = [img for img in images if img["brew"]["build"] not in skip_nvrs]
 
         rpm_names = [koji.parse_NVR(rpm_nvr)["name"] for rpm_nvr in rpm_nvrs]
 

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -769,6 +769,19 @@ class ArtifactBuild(FreshmakerBase):
         """Check if composes this build has have been done in ODCS"""
         return all((rel.compose.finished for rel in self.composes))
 
+    @classmethod
+    def get_rebuilt_original_nvrs_by_search_key(cls, session, search_key, directly_affected=True):
+        """Get NVRs of original images which have been rebuilt successfully in events"""
+        builds = (
+            session.query(cls)
+            .filter(cls.event.has(search_key=search_key))
+            .filter(cls.state == ArtifactBuildState.DONE.value)
+        )
+        if directly_affected:
+            builds = builds.filter(cls.rebuild_reason == RebuildReason.DIRECTLY_AFFECTED.value)
+
+        return list({b.original_nvr for b in builds.all()})
+
 
 class Compose(FreshmakerBase):
     __tablename__ = 'composes'

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -475,7 +475,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
-            leaf_container_images=None)
+            leaf_container_images=None, skip_nvrs=None)
 
     @patch.object(freshmaker.conf, 'handler_build_allowlist', new={
         'RebuildImagesOnRPMAdvisoryChange': {
@@ -493,7 +493,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
-            leaf_container_images=None)
+            leaf_container_images=None, skip_nvrs=None)
 
     @patch.object(freshmaker.conf, 'handler_build_allowlist', new={
         'RebuildImagesOnRPMAdvisoryChange': {
@@ -512,7 +512,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=None, release_categories=None,
-            leaf_container_images=None)
+            leaf_container_images=None, skip_nvrs=None)
 
     @patch.object(freshmaker.conf, 'handler_build_allowlist', new={
         'RebuildImagesOnRPMAdvisoryChange': {
@@ -529,7 +529,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
-            leaf_container_images=None)
+            leaf_container_images=None, skip_nvrs=None)
 
     @patch.object(freshmaker.conf, 'handler_build_allowlist', new={
         'RebuildImagesOnRPMAdvisoryChange': {
@@ -547,7 +547,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['httpd-2.4-11.el7'], ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
-            leaf_container_images=["foo", "bar"])
+            leaf_container_images=["foo", "bar"], skip_nvrs=None)
 
     @patch.object(freshmaker.conf, 'handler_build_allowlist', new={
         'RebuildImagesOnRPMAdvisoryChange': {
@@ -566,7 +566,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             ['content-set-1', 'pulp_repo_x86_64'],
             filter_fnc=self.handler._filter_out_not_allowed_builds,
             published=True, release_categories=conf.lightblue_release_categories,
-            leaf_container_images=None)
+            leaf_container_images=None, skip_nvrs=None)
 
 
 class TestAllowBuild(helpers.ModelsTestCase):


### PR DESCRIPTION
When manual rebuild is triggered for an advisory, freshmaker rebuilds
all affected images by default, there are two ways to change this
default behavior:

1. Specify the "container_images" in manual requests
2. Use "freshmaker_event_id" in manual requests, then the rebuilt
images in specified freshmaker event will be skipped.

However, when there are many events created for an advisory due to
some reasons, it's hard to skip rebuilt images in old events. In this
change, freshmaker is changed to skip rebuilt images in events
triggered by the same advisory by default. This behavior can be
changed by using `{"skip_rebuilt": false}` in metadata of manual
rebuild requests, for example:

    curl -X POST -d '{"errata_id": 123, "metadata": {"skip_rebuilt": false}}' <url>

JIRA: CWFHEALTH-687