### PR TITLE
Retry LightBlue query when searching for images

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -38,6 +38,7 @@ from freshmaker import log, conf
 from freshmaker.kojiservice import koji_service
 from freshmaker.models import ArtifactBuild
 from freshmaker.utils import sorted_by_nvr, is_pkg_modular
+from freshmaker.utils import retry
 import koji
 
 
@@ -968,6 +969,7 @@ class LightBlue(object):
 
         return request
 
+    @retry(wait_on=requests.exceptions.ConnectionError, logger=log)
     def find_images_with_included_rpms(
             self, content_sets, rpm_nvrs, repositories, published=True,
             include_rpm_manifest=True):


### PR DESCRIPTION
This quickfix affects error when connection to LightBlue is closed
during the request for some reason. Now request will be repeated

JIRA: CWFHEALTH-716

Signed-off-by: Andrei Paplauski <apaplaus@redhat.com>