### PR TITLE
Fix manual value of ManualRebuildWithAdvisoryEvent events

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -332,6 +332,7 @@ class ManualRebuildWithAdvisoryEvent(ErrataAdvisoryRPMsSignedEvent):
         """
         super(ManualRebuildWithAdvisoryEvent, self).__init__(
             msg_id, advisory, **kwargs)
+        self.manual = True
         self.container_images = container_images
         self.requester_metadata_json = requester_metadata_json
         self.requester = requester


### PR DESCRIPTION
It was changed by accident in ac0663c6 (in parse_post_data of
parsers/internal/manual_rebuild.py), set it in event directly
is better.