### PR TITLE
Set alembic version to <1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic<1.7
 fedmsg
 moksha.hub
 psutil


### PR DESCRIPTION
alembic >= 1.7 is not compatible with the migrations, this fixes
the mypy test failure:

    freshmaker/migrations/env.py:9: error: Module has no attribute "config"; maybe "configure"?