### PR TITLE
Don't run the handlers for unrelated messages

### DIFF
--- a/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
+++ b/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
@@ -39,14 +39,20 @@ class UpdateDBOnODCSComposeFail(BaseHandler):
     def can_handle(self, event):
         if not isinstance(event, ODCSComposeStateChangeEvent):
             return False
+
+        compose_id = event.compose["id"]
+
+        # check db to see whether this compose exists in db
+        found_compose = Compose.query.filter_by(odcs_compose_id=compose_id).first()
+
+        if not found_compose:
+            return False
         return event.compose["state"] == COMPOSE_STATES["failed"]
 
     @fail_event_on_handler_exception
     def handle(self, event):
 
         compose_id = event.compose["id"]
-        if Compose.query.filter_by(odcs_compose_id=compose_id).first() is None:
-            return
 
         self.log_error("ODCS compose %s failed", compose_id)
 

--- a/freshmaker/handlers/koji/rebuild_images_on_odcs_compose_done.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_odcs_compose_done.py
@@ -39,6 +39,14 @@ class RebuildImagesOnODCSComposeDone(ContainerBuildHandler):
     def can_handle(self, event):
         if not isinstance(event, ODCSComposeStateChangeEvent):
             return False
+
+        compose_id = event.compose['id']
+
+        # check db to see whether this compose exists in db
+        found_compose = Compose.query.filter_by(odcs_compose_id=compose_id).first()  # db.session.query(ArtifactBuild).filter_by(odcs_compose_id=compose_id).first()
+
+        if not found_compose:
+            return False
         return event.compose['state'] == COMPOSE_STATES['done']
 
     @fail_event_on_handler_exception
@@ -47,8 +55,6 @@ class RebuildImagesOnODCSComposeDone(ContainerBuildHandler):
             self.force_dry_run()
 
         compose_id = event.compose['id']
-        if Compose.query.filter_by(odcs_compose_id=compose_id).first() is None:
-            return
 
         self.log_info('ODCS compose %s finished', compose_id)
 

--- a/tests/handlers/koji/test_rebuild_images_on_parent_image_build.py
+++ b/tests/handlers/koji/test_rebuild_images_on_parent_image_build.py
@@ -38,19 +38,19 @@ class TestRebuildImagesOnParentImageBuild(helpers.ModelsTestCase):
         events.BaseEvent.register_parser(BrewTaskStateChangeParser)
         self.handler = RebuildImagesOnParentImageBuild()
 
-    def test_can_handle_brew_container_task_closed_event(self):
+    def test_can_not_handle_brew_container_task_closed_event(self):
         """
         Tests handler can handle brew build container task closed event.
         """
         event = self.get_event_from_msg(get_fedmsg('brew_container_task_closed'))
-        self.assertTrue(self.handler.can_handle(event))
+        self.assertFalse(self.handler.can_handle(event))
 
-    def test_can_handle_brew_container_task_failed_event(self):
+    def test_can_not_handle_brew_container_task_failed_event(self):
         """
         Tests handler can handle brew build container task failed event.
         """
         event = self.get_event_from_msg(get_fedmsg('brew_container_task_failed'))
-        self.assertTrue(self.handler.can_handle(event))
+        self.assertFalse(self.handler.can_handle(event))
 
     @mock.patch('freshmaker.handlers.ContainerBuildHandler.build_image_artifact_build')
     @mock.patch('freshmaker.handlers.ContainerBuildHandler.get_repo_urls')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -92,9 +92,10 @@ class ConsumerTest(helpers.ConsumerBaseTest):
                 return int(float(v))
         return None
 
+    @mock.patch("freshmaker.handlers.internal.UpdateDBOnODCSComposeFail.can_handle")
     @mock.patch("freshmaker.handlers.internal.UpdateDBOnODCSComposeFail.handle")
     @mock.patch("freshmaker.consumer.get_global_consumer")
-    def test_consumer_processing_message(self, global_consumer, handle):
+    def test_consumer_processing_message(self, global_consumer, handle, handler_can_handle):
         """
         Tests that consumer parses the message, forwards the event
         to proper handler and is able to get the further work from
@@ -103,6 +104,8 @@ class ConsumerTest(helpers.ConsumerBaseTest):
         consumer = self.create_consumer()
         global_consumer.return_value = consumer
         handle.return_value = [freshmaker.events.TestingEvent("ModuleBuilt handled")]
+
+        handler_can_handle.return_value = True
 
         prev_counter_value = self._get_monitor_value("messaging_rx_processed_ok_total")
 


### PR DESCRIPTION
Don't run the handlers for messages of unrelated odcs composes or brew tasks
(CWFHEALTH-706)