### PR TITLE
Update default fedmsg config for local dev env

### DIFF
--- a/fedmsg.d/freshmaker.py
+++ b/fedmsg.d/freshmaker.py
@@ -13,11 +13,11 @@ config = {
     # passive endpoints.  This placeholder value needs to be here for the tests
     # to pass in Jenkins, though.  \o/
     "endpoints": {
-        "fedora-infrastructure": [
-            # Just listen to staging for now, not to production (spam!)
-            # "tcp://hub.fedoraproject.org:9940",
-            "tcp://stg.fedoraproject.org:9940",
-        ],
+        # "fedora-infrastructure": [
+        #     # Just listen to staging for now, not to production (spam!)
+        #     # "tcp://hub.fedoraproject.org:9940",
+        #     "tcp://stg.fedoraproject.org:9940",
+        # ],
     },
 
     # Start of code signing configuration
@@ -42,8 +42,8 @@ config = {
 if 'FRESHMAKER_DEVELOPER_ENV' in os.environ and \
    os.environ['FRESHMAKER_DEVELOPER_ENV'].lower() in (
        '1', 'on', 'true', 'y', 'yes'):
-    config['endpoints']['relay_outbound'] = ["tcp://fedmsg-relay:2001"]
-    config['relay_inbound'] = ["tcp://fedmsg-relay:2003"]
+    config['endpoints']['relay_outbound'] = ["tcp://127.0.0.1:2001"]
+    config['relay_inbound'] = ["tcp://127.0.0.1:2003"]
 else:
     # These configuration values are reasonable for most other configurations.
     config['endpoints']['relay_outbound'] = ["tcp://127.0.0.1:4001"]


### PR DESCRIPTION
1. disable fedora fedmsg endpoints by default
2. use 127.0.0.1 by default instead of host name 'fedmsg-relay'