### PR TITLE
Check bundle image's OpenShift versions range

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -107,9 +107,12 @@ class HandleBotasAdvisory(ContainerBuildHandler):
         self.set_context(db_event)
 
         self.start_to_build_images(builds)
-        msg = f"Advisory {db_event.search_key}: Rebuilding " \
-              f"{len(db_event.builds.all())} bundle images."
-        db_event.transition(EventState.BUILDING, msg)
+        if all([b.state == ArtifactBuildState.FAILED.value for b in builds]):
+            db_event.transition(EventState.FAILED, "All bundle rebuilds failed")
+        else:
+            msg = f"Advisory {db_event.search_key}: Rebuilding " \
+                  f"{len(db_event.builds.all())} bundle images."
+            db_event.transition(EventState.BUILDING, msg)
 
         return []
 

--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -217,3 +217,23 @@ def get_ocp_release_date(ocp_version):
     if not resp.ok:
         resp.raise_for_status()
     return resp.json()[0]['date_finish']
+
+
+def is_valid_ocp_versions_range(ocp_versions_range):
+    """ Check if an ocp_versions_range string is valid
+
+    :param str ocp_versions_range: the OpenShift versions range value
+    :return: True if the OpenShift versions range is valid, otherwise False
+    :rtype: bool
+    """
+    # Commas are generally not allowed in ocp versions range, and should not be used.
+    # For historical reasons, there are two special values that are currently allowed
+    # to contain commas, "v4.5,v4.6" and "v4.6,v4.5".
+    valid_commas_ranges = ["v4.5,v4.6", "v4.6,v4.5"]
+    if (
+        "," in ocp_versions_range and
+        ocp_versions_range.replace(" ", "") not in valid_commas_ranges
+    ):
+        return False
+
+    return True

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -829,6 +829,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         }
         mock_koji.return_value.get_build.side_effect = lambda x: koji_builds[x]
         self.handler._prepare_builds = MagicMock()
+        self.handler._prepare_builds.return_value = [MagicMock()]
         self.handler.start_to_build_images = MagicMock()
 
         self.handler.handle(event)

--- a/tests/test_kojiservice.py
+++ b/tests/test_kojiservice.py
@@ -48,3 +48,42 @@ def test_build_container_csv_mods(mock_koji):
             "scratch": False,
         },
     )
+
+
+@mock.patch("freshmaker.kojiservice.koji")
+def test_get_ocp_versions_range(mock_koji):
+    mock_session = mock.Mock()
+    mock_session.getBuild.return_value = {"id": 123}
+    archives = [{
+        "arch": "x86_64",
+        "btype": "image",
+        "extra": {
+            "docker": {
+                "config": {
+                    "architecture": "amd64",
+                    "config": {
+                        "Hostname": "c4b105e29878",
+                        "Labels": {
+                            "architecture": "x86_64",
+                            "com.redhat.component": "foobar-bundle-container",
+                            "com.redhat.delivery.backport": "true",
+                            "com.redhat.delivery.operator.bundle": "true",
+                            "com.redhat.openshift.versions": "v4.5,v4.6"
+                        }
+                    },
+                    "os": "linux"
+                },
+                "id": "sha256:123"
+            },
+            "image": {
+                "arch": "x86_64"
+            }
+        },
+        "type_name": "tar"
+    }]
+
+    mock_session.listArchives.return_value = archives
+    mock_koji.ClientSession.return_value = mock_session
+
+    svc = kojiservice.KojiService()
+    assert svc.get_ocp_versions_range('foobar-2-123') == "v4.5,v4.6"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ import pytest
 
 from freshmaker import conf
 from freshmaker.models import ArtifactType
-from freshmaker.utils import get_rebuilt_nvr, sorted_by_nvr
+from freshmaker.utils import get_rebuilt_nvr, sorted_by_nvr, is_valid_ocp_versions_range
 from tests import helpers
 
 
@@ -38,6 +38,16 @@ def test_get_rebuilt_nvr(mock_time, rebuilt_nvr_release_suffix):
     with patch.object(conf, "rebuilt_nvr_release_suffix", new=rebuilt_nvr_release_suffix):
         rebuilt_nvr = get_rebuilt_nvr(ArtifactType.IMAGE.value, nvr)
     assert rebuilt_nvr == expected
+
+
+def test_is_valid_ocp_versions_range():
+    assert is_valid_ocp_versions_range("v4.8")
+    assert is_valid_ocp_versions_range("=v4.8")
+    assert is_valid_ocp_versions_range("v4.7-v4.8")
+    assert is_valid_ocp_versions_range("v4.5,v4.6")
+    assert is_valid_ocp_versions_range("v4.6,v4.5")
+    assert is_valid_ocp_versions_range("v4.5, v4.6")
+    assert not is_valid_ocp_versions_range("v4.7,v4.8")
 
 
 class TestSortedByNVR(helpers.FreshmakerTestCase):


### PR DESCRIPTION
If original bundle image has invalid OpenShift versions range, build
system still can rebuild it, but the rebuilt image will be invalid and
can not be shipped. Before submit the build task, freshmaker can check
the OpenShift versions range, in case it has an invalid value,
freshmaker can just move the build to FAILED state and not submit the
build task.

JIRA: CWFHEALTH-701