### PR TITLE
Mark as FAILED images with unmatched module stream

### DIFF
--- a/freshmaker/handlers/koji/rebuild_images_on_parent_image_build.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_parent_image_build.py
@@ -27,7 +27,8 @@ from freshmaker import log
 from freshmaker import db
 from freshmaker.errata import Errata
 from freshmaker.events import (
-    BrewContainerTaskStateChangeEvent, ErrataAdvisoryRPMsSignedEvent)
+    BrewContainerTaskStateChangeEvent, ErrataAdvisoryRPMsSignedEvent,
+    ManualRebuildWithAdvisoryEvent)
 from freshmaker.models import ArtifactBuild, EVENT_TYPES
 from freshmaker.handlers import (ContainerBuildHandler,
                                  fail_artifact_build_on_handler_exception,
@@ -87,7 +88,9 @@ class RebuildImagesOnParentImageBuild(ContainerBuildHandler):
         if event.new_state == 'CLOSED':
             # if build is triggered by an advisory, verify the container
             # contains latest RPMs from the advisory
-            if found_build.event.event_type_id == EVENT_TYPES[ErrataAdvisoryRPMsSignedEvent]:
+            if found_build.event.event_type_id in (
+                    EVENT_TYPES[ErrataAdvisoryRPMsSignedEvent],
+                    EVENT_TYPES[ManualRebuildWithAdvisoryEvent]):
                 errata_id = found_build.event.search_key
                 # build_id is actually task id in build system, find out the actual build first
                 with koji_service(


### PR DESCRIPTION
When an RHSA has RPMs for a module stream, Freshmaker tries to
rebuild different versions of the image (example ruby-25, ruby-26,
ruby27), this is as expected because Freshmaker can not handle module
streams so it just rebuilds all images, and marks the unmatched
module streams as FAILED as a post build check. This seems not to
work when the build is manual. This change is making sure that it
works also for manual builds.

Signed-off-by: Giulia Naponiello <gnaponie@redhat.com>