### PR TITLE
Refactor the bundle rebuild handler

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -468,49 +468,23 @@ class BotasErrataShippedEvent(ErrataBaseEvent):
         super().__init__(msg_id, advisory, dry_run=dry_run)
 
 
-class ManualBundleRebuild(BaseEvent):
+class ManualBundleRebuildEvent(ErrataBaseEvent):
     """
     Event triggered when Release Driver requests manual rebuild
     OR when manual rebuild of bundles requested by person
     """
-    def __init__(self, msg_id, dry_run=False):
-        super().__init__(msg_id, manual=True, dry_run=dry_run)
-
-    def is_allowed(self, handler, **kwargs):
-        return super().is_allowed(handler, ArtifactType.IMAGE, **kwargs)
-
-    @classmethod
-    def from_manual_rebuild_request(cls, msg_id, advisory,
-                                    freshmaker_event_id=None,
-                                    container_images=[],
-                                    requester=None,
-                                    requester_metadata_json=None,
-                                    **kwargs):
-        event = cls(msg_id, **kwargs)
-        event.advisory = advisory
-        event.freshmaker_event_id = freshmaker_event_id
-        event.container_images = container_images
-        event.requester = requester
-        event.requester_metadata_json = requester_metadata_json
-        return event
-
-    @classmethod
-    def from_release_driver_request(cls, msg_id,
-                                    container_images,
-                                    bundle_images,
-                                    requester=None,
-                                    requester_metadata_json=None,
-                                    **kwargs):
-        event = cls(msg_id, **kwargs)
-        event.advisory = None
-        event.container_images = container_images
-        event.bundle_images = bundle_images
-        event.requester = requester
-        event.requester_metadata_json = requester_metadata_json
-        return event
+    def __init__(self, msg_id, advisory, container_images,
+                 requester_metadata_json=None, freshmaker_event_id=None,
+                 requester=None, dry_run=False, **kwargs):
+        super().__init__(
+            msg_id, advisory,
+            freshmaker_event_id=freshmaker_event_id, dry_run=dry_run, **kwargs
+        )
+        self.manual = True
+        self.container_images = container_images
+        self.requester_metadata_json = requester_metadata_json
+        self.requester = requester
 
     @property
     def search_key(self):
-        if self.advisory:
-            return self.advisory.errata_id
-        return self.msg_id
+        return str(self.advisory.errata_id)

--- a/freshmaker/handlers/__init__.py
+++ b/freshmaker/handlers/__init__.py
@@ -516,7 +516,7 @@ class ContainerBuildHandler(BaseHandler):
         # range, if its value is invalid, the build system can still rebuild it,
         # but the rebuilt image will be an invalid bundle image, so we just fail
         # it before submitting the build task.
-        build_bundle_event_types = (events.BotasErrataShippedEvent, events.ManualBundleRebuild)
+        build_bundle_event_types = (events.BotasErrataShippedEvent, events.ManualBundleRebuildEvent)
         # check ocp versions range of
         if build.event.event_type in build_bundle_event_types:
             with koji_service(

--- a/freshmaker/kojiservice.py
+++ b/freshmaker/kojiservice.py
@@ -407,6 +407,29 @@ class KojiService(object):
         with zipfile.open(csv_files[0]) as f:
             return yaml.safe_load(f)
 
+    @freshmaker.utils.retry(wait_on=(requests.Timeout, requests.ConnectionError), logger=log)
+    def get_bundle_related_images(self, build_nvr):
+        """
+        Return related images in bundle
+
+        :param str build_nvr: NVR of operator bundle build.
+        :return: related images in bundle build metadata
+        :rtype: dict
+        """
+        try:
+            buildinfo = self.get_build(build_nvr)
+            related_images = (
+                buildinfo.get('extra', {})
+                .get('image', {})
+                .get('operator_manifests', {})
+                .get('related_images', {})
+            )
+        except Exception as e:
+            log.error("Unable to get related images in build %s: %s", build_nvr, str(e))
+            raise
+
+        return related_images
+
 
 @contextlib.contextmanager
 def koji_service(profile=None, logger=None, login=True, dry_run=False):

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -47,7 +47,7 @@ from freshmaker.events import (
     ErrataAdvisoryStateChangedEvent, FreshmakerManualRebuildEvent,
     ODCSComposeStateChangeEvent, ManualRebuildWithAdvisoryEvent,
     FreshmakerAsyncManualBuildEvent, BotasErrataShippedEvent,
-    ManualBundleRebuild,
+    ManualBundleRebuildEvent,
     FlatpakModuleAdvisoryReadyEvent,
 )
 
@@ -68,7 +68,7 @@ EVENT_TYPES = {
     ManualRebuildWithAdvisoryEvent: 13,
     FreshmakerAsyncManualBuildEvent: 14,
     BotasErrataShippedEvent: 15,
-    ManualBundleRebuild: 16,
+    ManualBundleRebuildEvent: 16,
     FlatpakModuleAdvisoryReadyEvent: 17,
 }
 

--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -22,6 +22,7 @@
 
 import functools
 import requests
+import semver
 import subprocess
 import sys
 import tempfile
@@ -237,3 +238,17 @@ def is_valid_ocp_versions_range(ocp_versions_range):
         return False
 
     return True
+
+
+def is_valid_semver(version_string):
+    """ Check if version string is a valid semantic version
+
+    :param str version_string: version string
+    :return: True if version string is a valid semantic version, other False
+    :rtype: bool
+    """
+    try:
+        semver.parse(version_string)
+        return True
+    except ValueError:
+        return False

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -29,7 +29,7 @@ from freshmaker import db, conf
 from freshmaker.events import (
     BotasErrataShippedEvent,
     ManualRebuildWithAdvisoryEvent,
-    TestingEvent, ManualBundleRebuild)
+    TestingEvent, ManualBundleRebuildEvent)
 from freshmaker.handlers.botas import HandleBotasAdvisory
 from freshmaker.errata import ErrataAdvisory
 from freshmaker.models import Event, ArtifactBuild, ArtifactBuildState
@@ -86,10 +86,8 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 
     def test_can_handle_manual_rebuilds(self):
         handler = HandleBotasAdvisory()
-        event1 = ManualBundleRebuild.from_manual_rebuild_request("123", None)
-        event2 = ManualBundleRebuild.from_release_driver_request("123", [], [])
-        self.assertTrue(handler.can_handle(event1))
-        self.assertTrue(handler.can_handle(event2))
+        event = ManualBundleRebuildEvent("123", self.botas_advisory, [])
+        self.assertTrue(handler.can_handle(event))
 
     def test_handle_set_dry_run(self):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory,
@@ -107,34 +105,28 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 
         self.assertEqual(db_event.state, EventState.SKIPPED.value)
         self.assertTrue(db_event.state_reason.startswith(
-            "This image rebuild is not allowed by internal policy."))
+            "This event is not allowed by internal policy"))
 
     def test_handle_manual_isnt_allowed_by_internal_policy(self):
-        event1 = ManualBundleRebuild.from_manual_rebuild_request("test_msg_id1", None)
-        event2 = ManualBundleRebuild.from_release_driver_request("test_msg_id2", [], [])
+        event = ManualBundleRebuildEvent("test_msg_id1", self.botas_advisory, [])
 
-        self.handler.handle(event1)
-        self.handler.handle(event2)
-        db_event1 = Event.get(db.session, message_id='test_msg_id1')
-        db_event2 = Event.get(db.session, message_id='test_msg_id2')
+        self.handler.handle(event)
+        db_event = Event.get(db.session, message_id='test_msg_id1')
 
-        self.assertEqual(db_event1.state, EventState.SKIPPED.value)
-        self.assertTrue(db_event1.state_reason.startswith(
-            "This image rebuild is not allowed by internal policy."))
-        self.assertEqual(db_event2.state, EventState.SKIPPED.value)
-        self.assertTrue(db_event2.state_reason.startswith(
-            "This image rebuild is not allowed by internal policy."))
+        self.assertEqual(db_event.state, EventState.SKIPPED.value)
+        self.assertTrue(db_event.state_reason.startswith(
+            "This event is not allowed by internal policy"))
 
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory.start_to_build_images")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._prepare_builds")
-    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._handle_bundle_rebuild")
+    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_bundles_to_rebuild")
     @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory.allow_build")
-    def test_handle(self, allow_build, handle_bundle_rebuild, prepare_builds,
+    def test_handle(self, allow_build, get_bundles_to_rebuild, prepare_builds,
                     start_to_build_images):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
         db_event = Event.get_or_create_from_event(db.session, event)
         allow_build.return_value = True
-        handle_bundle_rebuild.return_value = [{"bundle": 1}, {"bundle": 2}]
+        get_bundles_to_rebuild.return_value = ([{"bundle": 1}, {"bundle": 2}], None)
         prepare_builds.return_value = [
             ArtifactBuild.create(db.session, db_event, "ed0", "image", 1234,
                                  original_nvr="some_name-2-12345",
@@ -147,10 +139,12 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         self.handler.handle(event)
 
         self.handler._prepare_builds.assert_called_once()
-        self.assertEqual(self.handler._prepare_builds.call_args[0][0], db_event)
-        self.assertEqual(self.handler._prepare_builds.call_args[0][1],
+        self.assertEqual(self.handler._prepare_builds.call_args[0][0],
                          [{"bundle": 1}, {"bundle": 2}])
 
+    @patch.object(conf, "handler_build_allowlist", new={
+        "HandleBotasAdvisory": {"image": {"advisory_name": "RHBA-2020"}}
+    })
     def test_handle_bundle_rebuild_auto(self):
         """ Test handling of AUTOMATICALLY triggered bundle rebuild"""
         # operators mapping
@@ -179,6 +173,16 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         image_by_digest = {
             "bundle_with_related_images_1_digest": {"brew": {"build": "bundle1_nvr-1-1"}},
             "bundle_with_related_images_2_digest": {"brew": {"build": "bundle2_nvr-1-1"}},
+        }
+        image_by_nvr = {
+            "bundle1_nvr-1-1": {"brew": {"build": "bundle1_nvr-1-1"}},
+            "bundle2_nvr-1-1": {"brew": {"build": "bundle2_nvr-1-1"}},
+            "bundle3_nvr-1-1": {"brew": {"build": "bundle3_nvr-1-1"}},
+            "bundle4_nvr-1-1": {"brew": {"build": "bundle4_nvr-1-1"}},
+        }
+        csv_data_by_nvr = {
+            "bundle1_nvr-1-1": ("image.1.2.3", "1.2.3"),
+            "bundle2_nvr-1-1": ("image.1.2.4", "1.2.4")
         }
         builds = {
             "bundle1_nvr-1-1": {
@@ -220,12 +224,18 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
         db_event = Event.get_or_create_from_event(db.session, event)
         self.handler.event = event
-        self.handler._create_original_to_rebuilt_nvrs_map = \
-            MagicMock(return_value={"original_1": "some_name-1-12345",
-                                    "original_2": "some_name_2-2-2"})
+        self.handler._create_original_to_rebuilt_nvrs_map = MagicMock(
+            return_value={"original_1": "some_name-1-12345", "original_2": "some_name_2-2-2"}
+        )
+        self.handler._get_bundle_csv_name_and_version = MagicMock(
+            side_effect=lambda x: csv_data_by_nvr[x]
+        )
+        self.handler._prepare_builds = MagicMock()
+        self.handler.start_to_build_images = MagicMock()
 
         def gmldbn(nvr, must_be_published=True):
             return nvr_to_digest[nvr]
+
         self.pyxis().get_manifest_list_digest_by_nvr.side_effect = gmldbn
         self.pyxis().get_operator_indices.return_value = []
         # Doens't matter what this method will return, because we override method
@@ -234,30 +244,25 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         # return bundles for original operator images
         self.pyxis().get_bundles_by_related_image_digest.side_effect = lambda x, y: bundles_with_related_images[x]
         self.pyxis().get_images_by_digest.side_effect = lambda x: [image_by_digest[x]]
+        self.pyxis().get_images_by_nvr.side_effect = lambda x: [image_by_nvr[x]]
         self.handler.image_has_auto_rebuild_tag = MagicMock(return_value=True)
         get_build = self.patcher.patch("freshmaker.kojiservice.KojiService.get_build")
         get_build.side_effect = lambda x: builds[x]
 
         now = datetime(year=2020, month=12, day=25, hour=0, minute=0, second=0)
         with freezegun.freeze_time(now):
-            bundles_to_rebuild = self.handler._handle_bundle_rebuild(db_event)
+            self.handler.handle(event)
 
-        self.assertNotEqual(db_event.state, EventState.SKIPPED.value)
-        get_build.assert_has_calls([call("bundle1_nvr-1-1"), call("bundle2_nvr-1-1")], any_order=True)
-        bundles_by_digest = {
-            "bundle_with_related_images_1_digest": {
-                "auto_rebuild": True,
-                "images": [{"brew": {"build": "bundle1_nvr-1-1"}}],
-                "nvr": "bundle1_nvr-1-1",
-                "osbs_pinning": True,
+        bundles_to_rebuild = [
+            {
                 "pullspec_replacements": [
                     {
                         "new": "registry/repo/operator1@some_name-1-12345_digest",
                         "original": "registry/repo/operator1:v2.2.0",
                         "pinned": True,
-                        "_old": "registry/repo/operator1@original_1_digest"
                     }
                 ],
+                "nvr": "bundle1_nvr-1-1",
                 "update": {
                     "metadata": {
                         "name": "image.1.2.3-0.1608854400.p",
@@ -266,19 +271,15 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                     "spec": {"version": "1.2.3+0.1608854400.p"},
                 },
             },
-            "bundle_with_related_images_2_digest": {
-                "auto_rebuild": True,
-                "images": [{"brew": {"build": "bundle2_nvr-1-1"}}],
-                "nvr": "bundle2_nvr-1-1",
-                "osbs_pinning": True,
+            {
                 "pullspec_replacements": [
                     {
                         "new": "registry/repo/operator2@some_name_2-2-2_digest",
                         "original": "registry/repo/operator2:v2.2.0",
                         "pinned": True,
-                        "_old": "registry/repo/operator2@original_2_digest"
                     }
                 ],
+                "nvr": "bundle2_nvr-1-1",
                 "update": {
                     "metadata": {
                         "name": "image.1.2.4-0.1608854400.p",
@@ -287,9 +288,18 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                     "spec": {"version": "1.2.4+0.1608854400.p"},
                 },
             },
-        }
-        self.assertCountEqual(bundles_to_rebuild, list(bundles_by_digest.values()))
+        ]
 
+        self.assertNotEqual(db_event.state, EventState.SKIPPED.value)
+        get_build.assert_has_calls(
+            [call("bundle1_nvr-1-1"), call("bundle2_nvr-1-1")], any_order=True
+        )
+        assert bundles_to_rebuild[0] in self.handler._prepare_builds.call_args.args[0]
+        assert bundles_to_rebuild[1] in self.handler._prepare_builds.call_args.args[0]
+
+    @patch.object(conf, "handler_build_allowlist", new={
+        "HandleBotasAdvisory": {"image": {"advisory_name": "RHBA-2020"}}
+    })
     @patch('freshmaker.models.Event.get_artifact_build_from_event_dependencies')
     def test_handle_bundle_rebuild_manual(self, get_dependent_event_build):
         """ Test handling of MANUALLY triggered bundle rebuild"""
@@ -345,6 +355,16 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             "bundle_with_related_images_3_digest": {"brew": {"build": "bundle3_nvr-1-1"}},
             "bundle_with_related_images_4_digest": {"brew": {"build": "bundle4_nvr-1-1"}},
         }
+        image_by_nvr = {
+            "bundle1_nvr-1-1": {"brew": {"build": "bundle1_nvr-1-1"}},
+            "bundle2_nvr-1-1": {"brew": {"build": "bundle2_nvr-1-1"}},
+            "bundle3_nvr-1-1": {"brew": {"build": "bundle3_nvr-1-1"}},
+            "bundle4_nvr-1-1": {"brew": {"build": "bundle4_nvr-1-1"}},
+        }
+        csv_data_by_nvr = {
+            "bundle1_nvr-1-1": ("image.1.2.3", "1.2.3"),
+            "bundle2_nvr-1-1": ("image.1.2.4", "1.2.4")
+        }
         builds = {
             "bundle1_nvr-1-1": {
                 "task_id": 1,
@@ -382,16 +402,24 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             }
         }
 
-        event = ManualBundleRebuild.from_manual_rebuild_request(
-            "test_msg_id", self.botas_advisory, "dependent_event_id",
-            container_images=["bundle1_nvr-1-1", "bundle2_nvr-1-1", "bundle4_nvr-1-1"])
+        event = ManualBundleRebuildEvent(
+            "test_msg_id", self.botas_advisory,
+            container_images=["bundle1_nvr-1-1", "bundle2_nvr-1-1", "bundle4_nvr-1-1"]
+        )
         db_event = Event.get_or_create_from_event(db.session, event)
         self.handler.event = event
-        self.handler._create_original_to_rebuilt_nvrs_map = \
-            MagicMock(return_value={"original_1": "some_name-1-12345",
-                                    "original_2": "some_name_2-2-2",
-                                    "original_3": "some_name_3-3-3",
-                                    "original_4": "some_name_4-4-4"})
+        self.handler._create_original_to_rebuilt_nvrs_map = MagicMock(
+            return_value={
+                "original_1": "some_name-1-12345",
+                "original_2": "some_name_2-2-2",
+                "original_3": "some_name_3-3-3",
+                "original_4": "some_name_4-4-4"
+            }
+        )
+        self.handler._get_bundle_csv_name_and_version = MagicMock(
+            side_effect=lambda x: csv_data_by_nvr[x]
+        )
+        self.handler._prepare_builds = MagicMock()
 
         def gmldbn(nvr, must_be_published=True):
             return nvr_to_digest[nvr]
@@ -403,6 +431,8 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         # return bundles for original operator images
         self.pyxis().get_bundles_by_related_image_digest.side_effect = lambda x, y: bundles_with_related_images[x]
         self.pyxis().get_images_by_digest.side_effect = lambda x: [image_by_digest[x]]
+        self.pyxis().get_images_by_nvr.side_effect = lambda x: [image_by_nvr[x]]
+        self.pyxis().is_bundle.return_value = True
         # ignore bundle because it was already built in dependent event
         get_dependent_event_build.side_effect = lambda x: True if x == 'bundle4_nvr-1-1' else False
         self.handler.image_has_auto_rebuild_tag = MagicMock(return_value=True)
@@ -411,24 +441,20 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 
         now = datetime(year=2020, month=12, day=25, hour=0, minute=0, second=0)
         with freezegun.freeze_time(now):
-            bundles_to_rebuild = self.handler._handle_bundle_rebuild(db_event)
+            self.handler.handle(event)
 
         self.assertNotEqual(db_event.state, EventState.SKIPPED.value)
         get_build.assert_has_calls([call("bundle1_nvr-1-1"), call("bundle2_nvr-1-1")], any_order=True)
-        bundles_by_digest = {
-            "bundle_with_related_images_1_digest": {
-                "auto_rebuild": True,
-                "images": [{"brew": {"build": "bundle1_nvr-1-1"}}],
-                "nvr": "bundle1_nvr-1-1",
-                "osbs_pinning": True,
+        bundles_to_rebuild = [
+            {
                 "pullspec_replacements": [
                     {
                         "new": "registry/repo/operator1@some_name-1-12345_digest",
                         "original": "registry/repo/operator1:v2.2.0",
                         "pinned": True,
-                        "_old": "registry/repo/operator1@original_1_digest"
                     }
                 ],
+                "nvr": "bundle1_nvr-1-1",
                 "update": {
                     "metadata": {
                         "name": "image.1.2.3-0.1608854400.p",
@@ -437,19 +463,15 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                     "spec": {"version": "1.2.3+0.1608854400.p"},
                 },
             },
-            "bundle_with_related_images_2_digest": {
-                "auto_rebuild": True,
-                "images": [{"brew": {"build": "bundle2_nvr-1-1"}}],
-                "nvr": "bundle2_nvr-1-1",
-                "osbs_pinning": True,
+            {
                 "pullspec_replacements": [
                     {
                         "new": "registry/repo/operator2@some_name_2-2-2_digest",
                         "original": "registry/repo/operator2:v2.2.0",
                         "pinned": True,
-                        "_old": "registry/repo/operator2@original_2_digest"
                     }
                 ],
+                "nvr": "bundle2_nvr-1-1",
                 "update": {
                     "metadata": {
                         "name": "image.1.2.4-0.1608854400.p",
@@ -458,165 +480,9 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
                     "spec": {"version": "1.2.4+0.1608854400.p"},
                 },
             },
-        }
-        self.assertCountEqual(bundles_to_rebuild, list(bundles_by_digest.values()))
-
-    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_csv_updates")
-    @patch("freshmaker.kojiservice.KojiService.get_build")
-    @patch("freshmaker.handlers.botas.botas_shipped_advisory.HandleBotasAdvisory._get_pullspecs_mapping")
-    def test_handle_release_driver_rebuild(self, get_pullspecs_mapping, get_build,
-                                           get_csv_updates):
-
-        get_pullspecs_mapping.return_value = {
-            "old_pullspec": "new_pullspec",
-            "old_pullspec_2": "new_pullspec_2"
-        }
-        build_by_nvr = {
-            "container_image_2_nvr": {"extra": {
-                "image": {
-                    "operator_manifests": {
-                        "related_images": {
-                            "pullspecs": [
-                                {
-                                    "new": "newer_pullspes",
-                                    "original": "original_pullspec",
-                                    "pinned": True,
-                                },
-                                {
-                                    "new": "old_pullspec_2",
-                                    "original": "original_pullspec_2",
-                                    "pinned": True,
-                                }
-                            ]
-                        }
-                    }
-                }
-            }}
-        }
-        bundle_pullspec_overrides = {
-            "pullspec_replacements": [{
-                "new": "old_pullspec",
-                "original": "original_pullspec_3",
-                "pinned": True
-            }]
-        }
-        digest_by_nvr = {
-            "container_image_1_nvr": "container_image_1_digest",
-            "container_image_2_nvr": "container_image_2_digest",
-        }
-        bundle_by_digest = {
-            "container_image_1_digest": [{
-                "bundle_path_digest": "bundle_1",
-                "csv_name": "image.1.2.5",
-                "version_original": "1.2.5",
-            }],
-            "container_image_2_digest": [{
-                "bundle_path_digest": "bundle_2",
-                "csv_name": "image.1.2.5",
-                "version_original": "1.2.5",
-            }],
-        }
-
-        event = ManualBundleRebuild.from_release_driver_request(
-            "test_msg_id",
-            container_images=["container_image_1_nvr", "container_image_2_nvr"],
-            bundle_images=[],
-            requester="release-driver",
-            requester_metadata_json={"rebuild_queue": []})
-
-        db_event = Event.get_or_create_from_event(db.session, event)
-        self.assertEqual(json.loads(db_event.requester_metadata), {"rebuild_queue": []})
-
-        self.handler.event = event
-        get_build.side_effect = lambda nvr: build_by_nvr[nvr]
-        build = ArtifactBuild.create(
-            db.session, db_event, "ed0", "image", 1234,
-            rebuilt_nvr="container_image_1_nvr")
-        build.bundle_pullspec_overrides = bundle_pullspec_overrides
-
-        def gmldbn(nvr, must_be_published=True):
-            return digest_by_nvr[nvr]
-        self.pyxis().get_manifest_list_digest_by_nvr.side_effect = gmldbn
-        self.pyxis().get_bundles_by_digest.side_effect = \
-            lambda digest: bundle_by_digest[digest]
-        get_csv_updates.return_value = {"update": "csv_update_placeholder"}
-        db.session.commit()
-
-        bundles_to_rebuild = self.handler._handle_release_driver_rebuild(db_event)
-
-        expected_bundles = [
-            {
-                "nvr": "container_image_1_nvr",
-                "update": "csv_update_placeholder",
-                "pullspec_replacements": [{
-                    "new": "new_pullspec",
-                    "original": "original_pullspec_3",
-                    "pinned": True
-                }]
-            },
-            {
-                "nvr": "container_image_2_nvr",
-                "update": "csv_update_placeholder",
-                "pullspec_replacements": [
-                    {
-                        "new": "newer_pullspes",
-                        "original": "original_pullspec",
-                        "pinned": True,
-                    },
-                    {
-                        "new": "new_pullspec_2",
-                        "original": "original_pullspec_2",
-                        "pinned": True,
-                    }
-                ],
-            }
         ]
-        self.assertCountEqual(bundles_to_rebuild, expected_bundles)
-        self.pyxis().get_manifest_list_digest_by_nvr.assert_has_calls(
-            [call("container_image_1_nvr"), call("container_image_2_nvr")],
-            any_order=True)
-        self.assertEqual(self.pyxis().get_bundles_by_digest.call_count, 2)
-        self.pyxis().get_bundles_by_digest.assert_has_calls(
-            [call("container_image_1_digest"), call("container_image_2_digest")],
-            any_order=True)
-
-    def test_get_pullspecs_mapping(self):
-        event = ManualBundleRebuild.from_release_driver_request(
-            "test_msg_id",
-            container_images=[],
-            bundle_images=["bundle_image_1", "bundle_image_2"])
-        event2 = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
-        db_event = Event.get_or_create_from_event(db.session, event2)
-        build = ArtifactBuild.create(
-            db.session, db_event, "ed0", "image", 1234,
-            rebuilt_nvr="bundle_image_1")
-        build.bundle_pullspec_overrides = {
-            "pullspec_replacements":
-                [
-                    {
-                        "new": "some_pullspec",
-                        "original": "original_pullspec",
-                        "pinned": True
-                    },
-                    {
-                        "new": "new_pullspec",
-                        "original": "original_pullspec",
-                        "pinned": True,
-                        "_old": "old_pullspec"
-                    }
-                ]
-        }
-        self.handler.event = event
-        db.session.commit()
-
-        with self.assertLogs("freshmaker", "WARNING") as log:
-            pullspec_map = self.handler._get_pullspecs_mapping()
-
-        expected_map = {
-            "old_pullspec": "new_pullspec"
-        }
-        self.assertTrue("Can't find build for a bundle image \"bundle_image_2\"" in log.output[0])
-        self.assertEqual(pullspec_map, expected_map)
+        assert bundles_to_rebuild[0] in self.handler._prepare_builds.call_args.args[0]
+        assert bundles_to_rebuild[1] in self.handler._prepare_builds.call_args.args[0]
 
     @patch.object(conf, "dry_run", new=True)
     @patch.object(conf, "handler_build_allowlist", new={
@@ -651,6 +517,9 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         }})
     def test_handle_no_digests_error(self):
         event = BotasErrataShippedEvent("test_msg_id", self.botas_advisory)
+        self.handler._create_original_to_rebuilt_nvrs_map = MagicMock(
+            return_value={"foo-1-2": "foo-1-2.15800001"}
+        )
         self.pyxis().get_manifest_list_digest_by_nvr.return_value = None
         self.botas_advisory._builds = {}
 
@@ -692,6 +561,11 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             "foo-1-2.123": "sha256:333",
             "bar-2-2.134": "sha256:444",
         }
+        image_by_nvr = {
+            "foo-a-bundle-2.1-2": {"brew": {"build": "foo-a-bundle-2.1-2"}},
+            "foo-b-bundle-3.1-2": {"brew": {"build": "foo-b-bundle-3.1-2"}},
+        }
+        self.pyxis().get_images_by_nvr.side_effect = lambda x: [image_by_nvr[x]]
 
         def gmldbn(nvr, must_be_published=True):
             return digests_by_nvrs[nvr]
@@ -781,55 +655,40 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
 
         self.pyxis().get_auto_rebuild_tags.side_effect = _fake_get_auto_rebuild_tags
 
-        koji_builds = {
-            "foo-a-bundle-2.1-2": {
-                "build_id": 123,
-                "extra": {
-                    "image": {
-                        "operator_manifests": {
-                            "related_images": {
-                                "created_by_osbs": True,
-                                "pullspecs": [
-                                    {
-                                        "new": "registry.example.com/foo/foo-container@sha256:111",
-                                        "original": "registry.exampl.com/foo/foo-container:0.1",
-                                        "pinned": True,
-                                    }
-                                ],
-                            }
-                        },
-                    }
-                },
-                "name": "foo-a-bundle",
-                "nvr": "foo-a-bundle-2.1-2",
+        csv_data_by_nvr = {
+            "foo-a-bundle-2.1-2": ("image.2.1.2", "2.1.2"),
+            "foo-b-bundle-3.1-2": ("image.3.1.2", "3.1.2")
+        }
+        self.handler._get_bundle_csv_name_and_version = MagicMock(
+            side_effect=lambda x: csv_data_by_nvr[x]
+        )
 
+        build_related_images = {
+            "foo-a-bundle-2.1-2": {
+                "created_by_osbs": True,
+                "pullspecs": [
+                    {
+                        "new": "registry.example.com/foo/foo-container@sha256:111",
+                        "original": "registry.exampl.com/foo/foo-container:0.1",
+                        "pinned": True,
+                    }
+                ],
             },
             "foo-b-bundle-3.1-2": {
-                "build_id": 234,
-                "extra": {
-                    "image": {
-                        "operator_manifests": {
-                            "related_images": {
-                                "created_by_osbs": True,
-                                "pullspecs": [
-                                    {
-                                        "new": "registry.example.com/foo/foo-container@sha256:111",
-                                        "original": "registry.exampl.com/foo/foo-container:0.1",
-                                        "pinned": True,
-                                    }
-                                ],
-                            }
-                        },
+                "created_by_osbs": True,
+                "pullspecs": [
+                    {
+                        "new": "registry.example.com/foo/foo-container@sha256:111",
+                        "original": "registry.exampl.com/foo/foo-container:0.1",
+                        "pinned": True,
                     }
-                },
-                "name": "foo-b-bundle",
-                "nvr": "foo-b-bundle-3.1-2",
-
+                ],
             }
         }
-        mock_koji.return_value.get_build.side_effect = lambda x: koji_builds[x]
+        mock_koji.return_value.get_bundle_related_images.side_effect = lambda x: build_related_images[x]
         self.handler._prepare_builds = MagicMock()
         self.handler._prepare_builds.return_value = [MagicMock()]
+        self.handler.image_has_auto_rebuild_tag = MagicMock(return_value=True)
         self.handler.start_to_build_images = MagicMock()
 
         self.handler.handle(event)
@@ -971,13 +830,11 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
         pullspec_override_url = "https://localhost/api/2/pullspec_overrides/"
         db_event = Event.create(db.session, "id1", "RHSA-1", TestingEvent)
         db.session.commit()
+        self.handler.db_event = db_event
 
         bundle_data = [
             {
-                "images": ["image1", "image2"],
                 "nvr": "nvr-1-1",
-                "auto_rebuild": True,
-                "osbs_pinning": True,
                 "pullspec_replacements": [{
                     'new': 'registry/repo/operator@sha256:123',
                     'original': 'registry/repo/operator:v2.2.0',
@@ -995,7 +852,7 @@ class TestBotasShippedAdvisory(helpers.ModelsTestCase):
             }
         ]
 
-        ret_builds = self.handler._prepare_builds(db_event, bundle_data)
+        ret_builds = self.handler._prepare_builds(bundle_data)
 
         builds = ArtifactBuild.query.all()
         self.assertEqual(builds, ret_builds)


### PR DESCRIPTION
The main changes are:

1. While rebuilding unreleased bundles, freshmaker tries to get
   bundle data from Pyxis, but actually Pyxis doesn't have bundle
   data for unreleased bundles, this is fixed to use brew to get
   bundle data.
2. Instead of getting all latest bundles first and check one by one,
   use related image digest to get impacted bundles.
3. The manual case and auto case were handled differently, now they
   are handled with same workflow.
4. Manual rebuild request is refactored to only use advisory to find
   and construct the updated CSV data. "bundle_images" in request is
   not used anymore.

JIRA: CWFHEALTH-914