### PR TITLE
Update bob msg handler

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -304,18 +304,6 @@ class Config(object):
             'type': str,
             'default': '',
             'desc': 'Password to login Pulp.'},
-        'pulp_docker_server_url': {
-            'type': str,
-            'default': '',
-            'desc': 'Server URL of Pulp Docker.'},
-        'pulp_docker_username': {
-            'type': str,
-            'default': '',
-            'desc': 'Username to login Pulp Docker.'},
-        'pulp_docker_password': {
-            'type': str,
-            'default': '',
-            'desc': 'Password to login Pulp Docker.'},
         'bob_server_url': {
             'type': str,
             'default': '',

--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -253,15 +253,12 @@ class Errata(object):
         get_advisory_cdn_docker_file_list
         :param int errata_id: Errata advisory ID.
         :rtype: dict
-        :return: Dict of advisory builds with repo and tag config:
+        :return: Dict of repos and tags config:
             {
-                'build_NVR': {
-                    'cdn_repo1': [
-                        'tag1',
-                        'tag2'
-                    ],
-                    ...
-                },
+                'cdn_repo1': [
+                    'tag1',
+                    'tag2'
+                ],
                 ...
             }
         """
@@ -276,15 +273,11 @@ class Errata(object):
                         "returned None.")
             return None
 
-        repo_tags = dict()
-        for build_nvr in response:
-            if build_nvr not in repo_tags:
-                repo_tags[build_nvr] = dict()
-            repos = response[build_nvr]['docker']['target']['repos']
-            for repo in repos:
-                tags = repos[repo]['tags']
-                repo_tags[build_nvr][repo] = tags
-        return repo_tags
+        return {
+            repo: repo_data['tags']
+            for build_data in response.values()
+            for repo, repo_data in build_data['docker']['target']['external_repos'].items()
+        }
 
     def advisories_from_event(self, event):
         """

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -545,7 +545,7 @@ class TestErrata(helpers.FreshmakerTestCase):
                 'foo-container-1-1': {
                     'docker': {
                         'target': {
-                            'repos': {
+                            'external_repos': {
                                 'foo-526': {'tags': ['5.26', 'latest']}
                             }
                         }
@@ -554,7 +554,33 @@ class TestErrata(helpers.FreshmakerTestCase):
             }
             repo_tags = self.errata.get_docker_repo_tags(28484)
 
-            expected = {'foo-container-1-1': {'foo-526': ['5.26', 'latest']}}
+            expected = {'foo-526': ['5.26', 'latest']}
+            self.assertEqual(repo_tags, expected)
+
+        with patch.object(self.errata, "xmlrpc") as xmlrpc:
+            xmlrpc.get_advisory_cdn_docker_file_list.return_value = {
+                'foo-container-1-1': {
+                    'docker': {
+                        'target': {
+                            'external_repos': {
+                                'foo-526': {'tags': ['5.26', 'latest']}
+                            }
+                        }
+                    }
+                },
+                'bar-container-1-1': {
+                    'docker': {
+                        'target': {
+                            'external_repos': {
+                                'bar-526': {'tags': ['5.27', 'latest']}
+                            }
+                        }
+                    }
+                }
+            }
+            repo_tags = self.errata.get_docker_repo_tags(28484)
+
+            expected = {'bar-526': ['5.27', 'latest'], 'foo-526': ['5.26', 'latest']}
             self.assertEqual(repo_tags, expected)
 
     def test_get_docker_repo_tags_xmlrpc_exception(self):


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/CWFHEALTH-859

**Update Bob message handler to avoid usage of Docker-Pulp**
- updated `get_docker_repo_tags` to parse external repo names from ET response
        old response returned:  **{'foo-container-1-1': {'foo-526': ['5.26', 'latest']}}**
        new response returns: **{'foo-526': ['5.26', 'latest']}**
- updated `rebuild_images_depending_on_advisory` to use updated `get_docker_repo_tags` and removed usage of Docker-pulp
- Removed docker pulp credentials from `config.py` and removed all instances of docker pulp usage from unit tests.