### PR TITLE
Change ImageGroup methods to be more efficient

### DIFF
--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -51,16 +51,20 @@ class ImageGroup:
         self.repos = {x["repository"] for x in repositories}
 
     def __eq__(self, other):
-        return all(
-            [self.name == other.name and self.version == other.version and self.repos == other.repos]
+        return (
+            self.name == other.name and
+            self.version == other.version and
+            self.repos == other.repos
         )
 
     def __str__(self):
         return "%s-%s-%s" % (self.name, self.version, sorted(self.repos))
 
     def issubset(self, other):
-        return all(
-            [self.name == other.name and self.version == other.version and self.repos.issubset(other.repos)]
+        return (
+            self.name == other.name and
+            self.version == other.version and
+            self.repos.issubset(other.repos)
         )
 
 


### PR DESCRIPTION
This change is in regards to the comment mentioned from https://github.com/redhat-exd-rebuilds/freshmaker/pull/122

**tl;dr**:
It'd be simpler and more efficient to change this:
``` 
return all(
            [self.name == other.name and self.version == other.version and self.repos == other.repos]
        )
```
to
```
return self.name == other.name and self.version == other.version and self.repos == other.repos
```
because as of now, we are creating a list with a single boolean value and then calling the all function against it.