### PR TITLE
Make Freshmaker ignore operator hotfix images

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -215,6 +215,12 @@ class HandleBotasAdvisory(ContainerBuildHandler):
             # images in related images
             bundle_nvrs = self._get_impacted_bundles(original_digests_by_nvr.values())
 
+        # Create a new list which only contains images that are not hotfixes
+        for nvr in bundle_nvrs[:]:
+            if self._pyxis.is_hotfix_image(nvr):
+                bundle_nvrs.remove(nvr)
+                log.debug("Excluding hotfix bundle: %s", nvr)
+
         if not bundle_nvrs:
             return None, f"No bundle image is impacted by {self.event.advisory.errata_id}, skip."
 

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -339,3 +339,17 @@ class Pyxis(object):
                 if set(tag['name'] for tag in repo['tags']) & set(auto_rebuild_tags):
                     return True
         return False
+
+    def is_hotfix_image(self, image_nvr):
+        """
+        Checks if image_nvr is a hotfix image
+
+        :param str image_nvr: image_nvr
+        :return: True if image is a hotfix image, otherwise False
+        :rtype: bool
+        """
+        image = self.get_images_by_nvr(image_nvr, include=["data.parsed_data"])
+        if not image:
+            raise Exception("Image %s was not found in Pyxis", image_nvr)
+        # images for different arches contain the same label names, so just check the first image
+        return any(label["name"] == "com.redhat.hotfix" for label in image[0]["parsed_data"]["labels"])

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -601,6 +601,36 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
         is_bundle = self.px.is_bundle("foobar-bundle-1-234")
         self.assertFalse(is_bundle)
 
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_is_hotfix_image_true(self, page):
+        page.return_value = [{
+            "parsed_data": {
+                "labels": [
+                    {"name": "com.redhat.hotfix", "value": "bz1234567"},
+                    {"name": "architecture", "value": "ppc64le"},
+                    {"name": "brew", "value": "brew_value_1"},
+                    {"name": "repositories", "value": "repositories_value_1"},
+                ]
+            },
+        }]
+        is_hotfix_image = self.px.is_hotfix_image("foobar-bundle-1-234")
+        self.assertTrue(is_hotfix_image)
+
+    @patch('freshmaker.pyxis.Pyxis._pagination')
+    def test_is_hotfix_image_false(self, page):
+        page.return_value = [{
+            "parsed_data": {
+                "labels": [
+                    {"name": "not_com.redhat.hotfix", "value": "bz1234567"},
+                    {"name": "architecture", "value": "ppc64le"},
+                    {"name": "brew", "value": "brew_value_2"},
+                    {"name": "repositories", "value": "repositories_value_2"},
+                ]
+            },
+        }]
+        is_hotfix_image = self.px.is_hotfix_image("foobar-bundle-1-234")
+        self.assertFalse(is_hotfix_image)
+
     @patch('freshmaker.pyxis.Pyxis.get_auto_rebuild_tags')
     @patch('freshmaker.pyxis.Pyxis._pagination')
     def test_image_is_tagged_auto_rebuild(self, page, get_auto_rebuild_tags):


### PR DESCRIPTION
CWFHEALTH-908: "Ensure Freshmaker ignores hotfix images and does not try to rebuild them, or use them to trigger other rebuilds."
