### PR TITLE
Change Errata API to get attached builds NVRs

### DIFF
--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -482,28 +482,6 @@ class Errata(object):
 
         return list(nvrs)
 
-    def get_cve_affected_build_nvrs(self, errata_id, only_modules=False):
-        """ Get module build NVRs which are affected by the CVEs in errata
-
-        :param errata_id: Errata advisory ID, e.g. 25713.
-        :type errata_id: str or int
-        :param only_modules: only return module builds NVR if True.
-        :type only_modules: bool
-        :return: a list of strings each of them is a build NVR
-        :rtype: list
-        """
-        data = self._errata_rest_get(f"/erratum/{errata_id}/builds_by_cve")
-        nvrs = set()
-        for data_by_product in data.values():
-            for product_data in data_by_product.values():
-                for build in product_data.get("builds", []):
-                    for build_info in build.values():
-                        if only_modules and not build_info.get("is_module"):
-                            continue
-                        nvrs.add(build_info.get("nvr"))
-
-        return list(nvrs)
-
     def get_blocking_advisories_builds(self, errata_id):
         """ Get all advisories that block given advisory id, and fetch all builds from it
 
@@ -521,3 +499,18 @@ class Errata(object):
                 for build in builds:
                     nvrs.update(set(build.keys()))
         return nvrs
+
+    def get_attached_build_nvrs(self, errata_id):
+        """ Get all attached builds' NVRs
+
+        :param number errata_id: ID of advisory
+        :return: NVRs of attached builds
+        :rtype: set
+        """
+        product_builds = self._get_attached_builds(errata_id)
+        return {
+            nvr
+            for builds in product_builds.values()
+            for build in builds
+            for nvr in build.keys()
+        }

--- a/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
+++ b/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
@@ -90,8 +90,8 @@ class RebuildFlatpakApplicationOnModuleReady(ContainerBuildHandler):
         self.set_context(db_event)
 
         self.errata = Errata()
-        self.advisory_module_nvrs = self.errata.get_cve_affected_build_nvrs(
-            event.advisory.errata_id, True
+        self.advisory_module_nvrs = self.errata.get_attached_build_nvrs(
+            event.advisory.errata_id
         )
 
         try:

--- a/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
+++ b/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
@@ -84,7 +84,6 @@ class TestFlatpakModuleAdvisoryReadyEvent(helpers.ModelsTestCase):
         self.mock_errata = self._patch(
             "freshmaker.handlers.koji.rebuild_flatpak_application_on_module_ready.Errata"
         )
-        self.mock_errata.return_value.get_cve_affected_build_nvrs.return_value = []
 
         self.event = FlatpakModuleAdvisoryReadyEvent("123", self.advisory)
 

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -454,90 +454,29 @@ class TestErrata(helpers.FreshmakerTestCase):
 
     @patch.object(Errata, "_errata_rest_get")
     @patch.object(Errata, "_errata_http_get")
+    def test_get_attached_build_nvrs(
+            self, errata_http_get, errata_rest_get):
+        api = MockedErrataAPI(errata_rest_get, errata_http_get)
+        api.builds_json = {
+            "PRODUCT1": [
+                {
+                    "libreoffice-flatpak-8050020220215203934.84f422e1":
+                    {
+                        "Hidden-PRODUCT2":
+                            {"x86_64": ["libfontenc-1.1.3-8.module+el8.5.0+12446+59af0ebd.x86_64.rpm"]}
+                    }
+                }
+            ]
+        }
+        ret = self.errata.get_attached_build_nvrs(28484)
+        self.assertEqual(ret, {"libreoffice-flatpak-8050020220215203934.84f422e1"})
+
+    @patch.object(Errata, "_errata_rest_get")
+    @patch.object(Errata, "_errata_http_get")
     def test_errata_get_cve_affected_rpm_nvrs(self, errata_http_get, errata_rest_get):
         MockedErrataAPI(errata_rest_get, errata_http_get)
         ret = self.errata.get_cve_affected_rpm_nvrs(28484)
         self.assertEqual(ret, ['libntirpc-1.4.3-4.el6rhs'])
-
-    @patch.object(Errata, "_errata_rest_get")
-    @patch.object(Errata, "_errata_http_get")
-    def test_errata_get_cve_affected_build_nvrs(self, errata_http_get, errata_rest_get):
-        mocked_errata = MockedErrataAPI(errata_rest_get, errata_http_get)
-        ret = self.errata.get_cve_affected_build_nvrs(28484)
-        self.assertEqual(ret, ['libntirpc-1.4.3-4.el6rhs'])
-        ret = self.errata.get_cve_affected_build_nvrs(28484, True)
-        self.assertEqual(ret, [])
-        mocked_errata.builds_by_cve = {
-            "CVE-2021-42574": {
-                "PRODUCT1": {
-                    "builds": [
-                        {
-                            "rust-toolset-rhel8-8050020211027231136.5c15747c": {
-                                "id": 1775730,
-                                "is_module": True,
-                                "nevr": "rust-toolset-0:rhel8-8050020211027231136.5c15747c",
-                                "nvr": "rust-toolset-rhel8-8050020211027231136.5c15747c",
-                                "variant_arch": {
-                                    "PRODUCT1": {
-                                        "SRPMS": [
-                                            "rust-1.54.0-3.module+el8.5.0+13074+d655d86c.src.rpm",
-                                            "rust-toolset-1.54.0-1.module+el8.5.0+12195+effd8a03.src.rpm"
-                                        ],
-                                        "aarch64": [
-                                            "cargo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "cargo-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "clippy-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "clippy-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rls-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rls-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-analysis-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-debugsource-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-doc-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-std-static-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-std-static-wasm32-unknown-unknown-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rust-toolset-1.54.0-1.module+el8.5.0+12195+effd8a03.aarch64.rpm",
-                                            "rustfmt-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm",
-                                            "rustfmt-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.aarch64.rpm"
-                                        ],
-                                        "noarch": [
-                                            "cargo-doc-1.54.0-3.module+el8.5.0+13074+d655d86c.noarch.rpm",
-                                            "rust-debugger-common-1.54.0-3.module+el8.5.0+13074+d655d86c.noarch.rpm",
-                                            "rust-gdb-1.54.0-3.module+el8.5.0+13074+d655d86c.noarch.rpm",
-                                            "rust-lldb-1.54.0-3.module+el8.5.0+13074+d655d86c.noarch.rpm",
-                                            "rust-src-1.54.0-3.module+el8.5.0+13074+d655d86c.noarch.rpm"
-                                        ],
-                                        "x86_64": [
-                                            "cargo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "cargo-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "clippy-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "clippy-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rls-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rls-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-analysis-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-debugsource-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-doc-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-std-static-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-std-static-wasm32-unknown-unknown-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rust-toolset-1.54.0-1.module+el8.5.0+12195+effd8a03.x86_64.rpm",
-                                            "rustfmt-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm",
-                                            "rustfmt-debuginfo-1.54.0-3.module+el8.5.0+13074+d655d86c.x86_64.rpm"
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    ],
-                    "description": "PRODUCT Version 1",
-                    "name": "PRODUCT1"
-                }
-            }
-        }
-        ret = self.errata.get_cve_affected_build_nvrs(28484, True)
-        self.assertEqual(ret, ['rust-toolset-rhel8-8050020211027231136.5c15747c'])
 
     def test_get_docker_repo_tags(self):
         with patch.object(self.errata, "xmlrpc") as xmlrpc:


### PR DESCRIPTION
As discussed in the doc:
https://docs.google.com/document/d/1SR0Rh6ynZc-09Um91VGn7rZ33IS-x4KwbJsT-9m5HFk/edit#bookmark=id.d0h5hmxobp81
The type of advisory for the Flatpak application module is RHBA,
so we should use API advisory/{id}/builds.json to get the
build NVRs instead of API erratum/{id}/builds_by_cve

JIRA: RHELWF-6103