### PR TITLE
Add new method to get build rpm nvrs

### DIFF
--- a/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
+++ b/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
@@ -212,7 +212,7 @@ class RebuildFlatpakApplicationOnModuleReady(ContainerBuildHandler):
         :return: a list of ContainerImage instances which can be auto rebuilt.
         :rtype: list
         """
-        errata_rpm_nvrs = self.errata.get_cve_affected_rpm_nvrs(
+        errata_rpm_nvrs = self.errata.get_binary_rpm_nvrs(
             self.event.advisory.errata_id
         )
         lb = LightBlue(


### PR DESCRIPTION
As the flatpak application advisory is not
restricted to CVE related, we need to use new
API to get build rpm nvrs.