### PR TITLE
Remove the check of composes from most original image

### DIFF
--- a/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
+++ b/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
@@ -319,7 +319,6 @@ class RebuildFlatpakApplicationOnModuleReady(ContainerBuildHandler):
                 self.set_context(db_event)
 
                 image.resolve_commit()
-                image.resolve_original_odcs_compose_ids(False)
                 nvr = image.nvr
                 image_name = koji.parse_NVR(nvr)["name"]
                 build = self.record_build(
@@ -344,7 +343,7 @@ class RebuildFlatpakApplicationOnModuleReady(ContainerBuildHandler):
                     version = mmd.get_version()
                     module_name_stream_set.add(f"{name}:{stream}")
                     module_name_stream_version_set.add(f"{name}:{stream}:{version}")
-                original_odcs_compose_ids = image["original_odcs_compose_ids"]
+                original_odcs_compose_ids = image["odcs_compose_ids"]
                 reused_composes = self._reused_composes(
                     original_odcs_compose_ids, module_name_stream_set
                 )

--- a/freshmaker/kojiservice.py
+++ b/freshmaker/kojiservice.py
@@ -335,21 +335,6 @@ class KojiService(object):
         return rpms
 
     @region.cache_on_arguments()
-    def get_odcs_compose_ids(self, build_nvr):
-        """
-        Get ODCS compose ids used in image build task
-
-        Return a list of compose ids
-        """
-        build = self.get_build(build_nvr)
-        # Get the list of ODCS composes used to build the image.
-        extra_image = build.get("extra", {}).get("image", {})
-        compose_ids = extra_image.get("odcs", {}).get("compose_ids")
-        if not compose_ids:
-            compose_ids = []
-        return compose_ids
-
-    @region.cache_on_arguments()
     def get_ocp_versions_range(self, build_nvr):
         """
         Get bundle image's OpenShift versions range value

--- a/freshmaker/models.py
+++ b/freshmaker/models.py
@@ -631,20 +631,6 @@ class ArtifactBuild(FreshmakerBase):
             return 0
         return build.build_id
 
-    @classmethod
-    def get_most_original_nvr(cls, nvr):
-        """
-        Get original NVR recursively until reach the one which was not built by freshmaker
-
-        Return the NVR of most original image
-        """
-        original_nvr = None
-        build = db.session.query(ArtifactBuild).filter(cls.rebuilt_nvr == nvr).first()
-        while build:
-            original_nvr = build.original_nvr
-            build = db.session.query(ArtifactBuild).filter(cls.rebuilt_nvr == original_nvr).first()
-        return original_nvr
-
     @property
     def bundle_pullspec_overrides(self):
         """Return the Python representation of the JSON bundle_pullspec_overrides."""

--- a/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
+++ b/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
@@ -25,7 +25,7 @@ def _mock_image(image_nvr):
         "target": "t1",
         "git_branch": "mybranch",
         "arches": "x86_64",
-        "original_odcs_compose_ids": [10, 11],
+        "odcs_compose_ids": [10, 11],
         "directly_affected": True,
     }
     return ContainerImage(d)
@@ -323,10 +323,6 @@ class TestFlatpakModuleAdvisoryReadyEvent(helpers.ModelsTestCase):
             "freshmaker.lightblue.ContainerImage.resolve_commit"
         )
         resolve_commit.return_value = None
-        resolve_original_odcs_compose_ids = self._patch(
-            "freshmaker.lightblue.ContainerImage.resolve_original_odcs_compose_ids"
-        )
-        resolve_original_odcs_compose_ids.return_value = None
 
         odcs = create_odcs_client.return_value
         composes = [

--- a/tests/handlers/koji/test_rebuild_images_on_async_manual_build.py
+++ b/tests/handlers/koji/test_rebuild_images_on_async_manual_build.py
@@ -64,8 +64,6 @@ class TestRebuildImagesOnAsyncManualBuild(helpers.ModelsTestCase):
         self.mock_start_to_build_images = self.patcher.patch('start_to_build_images')
         self.mock_get_image_builds_in_first_batch = self.patcher.patch(
             'freshmaker.models.Event.get_image_builds_in_first_batch')
-        self.mock_get_most_original_nvr = self.patcher.patch(
-            'freshmaker.models.ArtifactBuild.get_most_original_nvr')
 
         # Structure of the images used for testing:
         #       image_0

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -90,7 +90,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         self.image_b = ContainerImage({
@@ -111,7 +112,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         self.image_c = ContainerImage({
@@ -133,7 +135,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         self.image_d = ContainerImage({
@@ -155,7 +158,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         self.image_e = ContainerImage({
@@ -177,7 +181,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         self.image_f = ContainerImage({
@@ -199,7 +204,8 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
                 ]
             },
             "generate_pulp_repos": True,
-            "original_odcs_compose_ids": [],
+            "odcs_compose_ids": [],
+            "compose_sources": [],
             "published": False,
         })
         # For simplicify, mocking _find_images_to_rebuild to just return one
@@ -827,7 +833,8 @@ class TestBatches(helpers.ModelsTestCase):
             "content_sets": ["first-content-set"],
             "generate_pulp_repos": True,
             "arches": "x86_64",
-            "original_odcs_compose_ids": [10, 11],
+            "odcs_compose_ids": [10, 11],
+            "compose_sources": ["first-content-set"],
             "published": False,
         }
         d.update(kwargs)
@@ -1036,7 +1043,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1080,7 +1088,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })]
         ]
@@ -1127,7 +1136,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": False,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": ["content-set-1"],
                 "published": True,
             })]
         ]
@@ -1167,7 +1177,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "generate_pulp_repos": False,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })]
         ]
@@ -1206,8 +1217,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": None,
                 "arches": "x86_64",
-                "generate_pulp_repos": True,
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1251,7 +1262,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "error": None,
                 "arches": "x86_64",
                 "generate_pulp_repos": True,
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })]
         ]
@@ -1300,8 +1312,8 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": None,
                 "arches": "x86_64",
-                "generate_pulp_repos": True,
-                "original_odcs_compose_ids": [123],
+                "odcs_compose_ids": [123],
+                "compose_sources": ["content-set-1"],
                 "published": False,
             })]
         ]
@@ -1342,7 +1354,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occurs while getting this image.",
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1379,7 +1391,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occurs while getting this image.",
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1416,7 +1428,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured.",
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1459,7 +1471,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured too.",
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
                 "published": False,
             })]
         ]
@@ -1500,7 +1512,7 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "git_branch": "rhel-7",
                 "error": "Some error occured.",
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
                 "published": False,
             })],
         ]
@@ -1536,9 +1548,9 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "target": "target-candidate",
                 "git_branch": "rhel-7",
                 "error": None,
-                "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })],
             [ContainerImage({
@@ -1580,9 +1592,9 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
                 "target": "target-candidate",
                 "git_branch": "rhel-7",
                 "error": None,
-                "generate_pulp_repos": True,
                 "arches": "x86_64",
-                "original_odcs_compose_ids": [],
+                "odcs_compose_ids": [],
+                "compose_sources": [],
                 "published": False,
             })]
         ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,25 +209,6 @@ class TestModels(helpers.ModelsTestCase):
             'depends_on_events': [],
         })
 
-    def test_get_most_original_nvr(self):
-        event = Event.create(db.session, "test_msg_id", "test", events.TestingEvent)
-        ArtifactBuild.create(
-            db.session, event, "ubi", "image", 1234,
-            original_nvr="ubi-2-1", rebuilt_nvr="ubi-2-1.1580000001"
-        )
-        ArtifactBuild.create(
-            db.session, event, "ubi", "image", 1235,
-            original_nvr="ubi-2-1.1580000001", rebuilt_nvr="ubi-2-1.1580000002"
-        )
-        ArtifactBuild.create(
-            db.session, event, "ubi", "image", 1236,
-            original_nvr="ubi-2-1.1580000002", rebuilt_nvr="ubi-2-1.1580000003"
-        )
-        db.session.commit()
-        db.session.expire_all()
-        nvr = ArtifactBuild.get_most_original_nvr("ubi-2-1.1580000003")
-        self.assertEqual(nvr, "ubi-2-1")
-
     def test_get_rebuilt_original_nvrs_by_search_key(self):
         event = Event.create(db.session, "test_msg_id", "12345", events.TestingEvent)
         ArtifactBuild.create(db.session, event, "foo", "image", 1001,


### PR DESCRIPTION
At the beginning, Freshmaker generates ODCS composes for enabled content
sets and build images with those composes, later OSBS was changed to
use ODCS to generate composes for content sets as well, but Freshmaker
continued to generate such composes no matter whether they have been in
original build's odcs composes or not, thus every time when Freshmaker
rebuilds an image, the composes will be added, that resulted in
repeated composes in image builds and caused some issues for base image
building.

To workaround the issue, 032f8272 was added to check composes from the
most original image, now it should be safe to remove this workaround.

In 032f8272, db queries are performed in multi-threading code, due to
that, SQLAlchemy engine can easily runs out of connections and raise
error like "QueuePool limit of size 5 overflow 10 reached", by removing
the check, we can also get rid of the issue without increasing the pool
size.

JIRA: CWFHEALTH-1372