### PR TITLE
Exclude hidden content_set

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -444,6 +444,11 @@ class Config(object):
             'default': 'lightblue',
             'desc': 'An option to get image metadata from LightBlue or Pyxis GraphQL. Can be set to "pyxis_graphql" or "lightblue".'
         },
+        'exclude_content_sets_pattern': {
+            'type': str,
+            'default': '-hidden-rpms$',
+            'desc': 'Pattern for content sets which will be excluded while generating composes'
+        },
     }
 
     def __init__(self, conf_section_obj):

--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -24,6 +24,7 @@
 
 import json
 import koji
+import re
 
 from freshmaker import conf, db
 from freshmaker.events import (
@@ -318,6 +319,9 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
                     missing_content_sets = set()
                     for content_set in image["content_sets"]:
                         if content_set in image["compose_sources"]:
+                            continue
+                        # Exclude hidden content set.
+                        if re.search(conf.exclude_content_sets_pattern, content_set):
                             continue
                         missing_content_sets.add(content_set)
 

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -1195,6 +1195,47 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
         self.assertEqual(ArtifactBuildState.PLANNED.value, parent_image.state)
         self.mock_prepare_pulp_repo.assert_called()
 
+    def test_record_batches_not_generate_hidden_pulp_repos(self):
+        batches = [
+            [ContainerImage({
+                "brew": {
+                    "completion_date": "20170420T17:05:37.000-0400",
+                    "build": "rhel-server-docker-7.3-82",
+                    "package": "rhel-server-docker"
+                },
+                'parsed_data': {
+                    'layers': [
+                        'sha512:12345678980',
+                        'sha512:10987654321'
+                    ]
+                },
+                "parent": None,
+                "content_sets": ["content-hidden-rpms"],
+                "repository": "repo-1",
+                "commit": "123456789",
+                "target": "target-candidate",
+                "git_branch": "rhel-7",
+                "error": None,
+                "generate_pulp_repos": False,
+                "arches": "x86_64",
+                "odcs_compose_ids": [],
+                "compose_sources": [],
+                "published": False,
+            })]
+        ]
+
+        handler = RebuildImagesOnRPMAdvisoryChange()
+        handler._record_batches(batches, self.mock_event)
+
+        # Check parent image
+        query = db.session.query(ArtifactBuild)
+        parent_image = query.filter(
+            ArtifactBuild.original_nvr == 'rhel-server-docker-7.3-82'
+        ).first()
+        self.assertNotEqual(None, parent_image)
+        self.assertEqual(ArtifactBuildState.PLANNED.value, parent_image.state)
+        self.mock_prepare_pulp_repo.assert_not_called()
+
     def test_pulp_compose_generated_just_once(self):
         batches = [
             [ContainerImage({


### PR DESCRIPTION
As described in RHELWF-5866, making compose failed when including hidden content_set, probably the reason is ODCS thinks it is unpublished content set.

JIRA: RHELWF-5866