### PR TITLE
Add a new option to get image metadata from LightBlue or Pyxis

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -439,6 +439,11 @@ class Config(object):
             'default': '',
             'desc': 'Root url of Flatpak index service'
         },
+        'container_metadata_source': {
+            'type': str,
+            'default': 'lightblue',
+            'desc': 'An option to get image metadata from LightBlue or Pyxis GraphQL. Can be set to "pyxis_graphql" or "lightblue".'
+        },
     }
 
     def __init__(self, conf_section_obj):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,9 @@ class TestConfig(helpers.FreshmakerTestCase):
             "freshmaker_cc_%s_%s" % (os.getpid(),
                                      threading.current_thread().ident))
 
+    def test_container_metadata_source(self):
+        self.assertTrue(conf.container_metadata_source == 'lightblue' or conf.container_metadata_source == 'pyxis_graphql')
+
 
 @pytest.mark.parametrize('value', (
     'not a dict',


### PR DESCRIPTION
Add an option in Freshmaker to switch between using LightBlue and Pyxis GraphQL; Jira: CWFHEALTH-1246