### PR TITLE
Use Pyxis GraphQL APIs to find repositories and images

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -58,8 +58,3 @@ Other
 
 * ``rebuilt_nvr_release_suffix`` - a suffix to add to the ``rebuilt_nvr``
   release in addition to the timestamp. This defaults to an empty string.
-
-* vcrpy - use this library for recording the Lightblue queries per
-  Freshmaker event. The importing of vcrpy and the recording of Lightblue queries is performed if
-  the vcrpy configuration variables (``vcrpy_path`` and ``vcrpy_mode``) are set in
-  ``freshmaker/config.py``

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -391,16 +391,6 @@ class Config(object):
             'default': ("Generally Available", "Tech Preview", "Beta",),
             'desc': 'Release categories',
         },
-        'vcrpy_path': {
-            'type': str,
-            'default': '',
-            'desc': 'vcr path where lightblue queries will be recorded'
-        },
-        'vcrpy_mode': {
-            'type': str,
-            'default': 'all',
-            'desc': 'vcr mode for recording lightblue queries'
-        },
         'pyxis_server_url': {
             'type': str,
             'default': '',
@@ -573,12 +563,6 @@ class Config(object):
         fixed_permissions = defaultdict(lambda: {'groups': [], 'users': []})
         fixed_permissions.update(permissions)
         self._permissions = fixed_permissions
-
-    def _setifok_vcrpy_path(self, s):
-        s = str(s)
-        if s:
-            import vcr  # noqa: F401
-        self._vcrpy_path = s
 
     def _get_krb_auth_ccache_file(self):
         if not self._krb_auth_ccache_file:

--- a/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
+++ b/freshmaker/handlers/koji/rebuild_flatpak_application_on_module_ready.py
@@ -218,8 +218,7 @@ class RebuildFlatpakApplicationOnModuleReady(ContainerBuildHandler):
         lb = LightBlue(
             server_url=conf.lightblue_server_url,
             cert=conf.lightblue_certificate,
-            private_key=conf.lightblue_private_key,
-            event_id=self.current_db_event_id,
+            private_key=conf.lightblue_private_key
         )
 
         if errata_rpm_nvrs:

--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -417,8 +417,7 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
         # content sets
         lb = LightBlue(server_url=conf.lightblue_server_url,
                        cert=conf.lightblue_certificate,
-                       private_key=conf.lightblue_private_key,
-                       event_id=self.current_db_event_id)
+                       private_key=conf.lightblue_private_key)
         # Check if we are allowed to rebuild unpublished images and clear
         # published and release_categories if so.
         if self.event.is_allowed(self, published=True):

--- a/freshmaker/lightblue.py
+++ b/freshmaker/lightblue.py
@@ -519,8 +519,7 @@ class LightBlue(object):
 
     def __init__(self, server_url, cert, private_key,
                  verify_ssl=None,
-                 entity_versions=None,
-                 event_id=None):
+                 entity_versions=None):
         """Initialize LightBlue instance
 
         :param str server_url: URL used to call LightBlue APIs. It is
@@ -538,7 +537,6 @@ class LightBlue(object):
         """
         self.server_url = server_url.rstrip('/')
         self.api_root = '{}/rest/data'.format(self.server_url)
-        self.event_id = event_id
         if verify_ssl is None:
             self.verify_ssl = True
         else:
@@ -569,7 +567,7 @@ class LightBlue(object):
         return self.entity_versions.get(entity_name, '')
 
     def _make_request(self, entity, data):
-        """Make a request to query data from LightBlue and save it if vcrpy is configured
+        """Make a request to query data from LightBlue
 
         :param str entity: the entity part to construct a full URL sent to
             LightBlue. Refer to callers of ``_make_request`` to learn what
@@ -591,16 +589,7 @@ class LightBlue(object):
             "cert": (self.cert, self.private_key),
             "headers": {'Content-Type': 'application/json'}
         }
-        if self.event_id and conf.vcrpy_path:
-            import vcr
-            my_vcr = vcr.VCR(
-                cassette_library_dir=conf.vcrpy_path,
-                record_mode=conf.vcrpy_mode,
-            )
-            with my_vcr.use_cassette(f'{self.event_id}.yml'):
-                response = requests.post(entity_url, **request_kwargs, timeout=conf.requests_timeout)
-        else:
-            response = requests.post(entity_url, **request_kwargs, timeout=max(600, conf.requests_timeout * 5))
+        response = requests.post(entity_url, **request_kwargs, timeout=max(600, conf.requests_timeout * 5))
 
         status_code = response.status_code
 

--- a/requirements.in
+++ b/requirements.in
@@ -31,3 +31,4 @@ jsonformatter
 # requires werkzeug.security.safe_str_cmp which is removed in v2.1.0
 Werkzeug<2.1
 gql[requests]
+PyYaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,6 +165,8 @@ python-ldap==3.4.3
     #   pyldap
 pytz==2022.1
     # via moksha-common
+pyyaml==6.0
+    # via -r requirements.in
 pyzmq==23.0.0
     # via
     #   fedmsg

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,6 @@ copr
 freezegun
 pytest
 pytest-cov
-vcrpy
 requests_mock
 tox
 mypy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@
 
 import flask
 import pytest
-from unittest import mock
 
 
 @pytest.fixture(autouse=True)
@@ -35,9 +34,3 @@ def clear_flask_g():
     for attr in ('group', 'user'):
         if hasattr(flask.g, attr):
             delattr(flask.g, attr)
-
-
-@pytest.fixture(autouse=True)
-def mock_vcrpy():
-    with mock.patch('vcr.VCR'):
-        yield

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -804,14 +804,6 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         self.patcher.unpatch_all()
         self.koji_read_config_patcher.stop()
 
-    @patch('os.path.exists', return_value=True)
-    def test_LightBlue_returns_event(self, exists):
-        lb = LightBlue(server_url=self.fake_server_url,
-                       cert=self.fake_cert_file,
-                       private_key=self.fake_private_key,
-                       event_id=self.current_db_event_id)
-        assert lb.event_id == self.current_db_event_id
-
     @patch('freshmaker.lightblue.requests.post')
     def test_find_container_images(self, post):
         post.return_value.status_code = http.client.OK

--- a/tests/test_lightblue.py
+++ b/tests/test_lightblue.py
@@ -590,6 +590,289 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             }
         }
 
+        foo_image_1_20_data = [
+            {
+                "architecture": "amd64",
+                "brew": {"build": "foo-container-1-20"},
+                "content_sets": ["foo-content-set-x86_64"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.x86_64"
+                                },
+                                {
+                                    "srpm_name": "tespackage",
+                                    "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                                    "name": "tespackage",
+                                    "nvra": "testpackage-1.2.3-1.x86_64"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parent_brew_build": "foo-parent-container-2-130",
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/foo-container/plain/Dockerfile?id=commit_hash1",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/foo",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+            {
+                "architecture": "ppc64le",
+                "brew": {"build": "foo-container-1-20"},
+                "content_sets": ["foo-content-set-ppc64le"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.ppc64le"
+                                },
+                                {
+                                    "srpm_name": "tespackage",
+                                    "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                                    "name": "tespackage",
+                                    "nvra": "testpackage-1.2.3-1.ppc64le"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parent_brew_build": "foo-parent-container-2-130",
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/foo-container/plain/Dockerfile?id=commit_hash1",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/foo",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+        ]
+
+        foo_parent_image_2_130_data = [
+            {
+                "architecture": "amd64",
+                "brew": {"build": "foo-parent-container-2-130"},
+                "content_sets": ["foo-content-set-x86_64"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.x86_64"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/foo-parent-container/plain/Dockerfile?id=commit_hash1",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/foo-parent",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+            {
+                "architecture": "ppc64le",
+                "brew": {"build": "foo-parent-container-2-130"},
+                "content_sets": ["foo-content-set-ppc64le"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.ppc64le"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/foo-parent-container/plain/Dockerfile?id=commit_hash1",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/foo-parent",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+        ]
+
+        bar_image_2_30_data = [
+            {
+                "architecture": "amd64",
+                "brew": {"build": "bar-container-2-30"},
+                "content_sets": ["bar-content-set-x86_64"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.x86_64"
+                                },
+                                {
+                                    "srpm_name": "tespackage",
+                                    "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                                    "name": "tespackage",
+                                    "nvra": "testpackage-1.2.3-1.x86_64"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parent_brew_build": "bar-parent-container-1-10",
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/bar-container/plain/Dockerfile?id=commit_hash2",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/bar",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+            {
+                "architecture": "ppc64le",
+                "brew": {"build": "bar-container-2-30"},
+                "content_sets": ["bar-content-set-ppc64le"],
+                "edges": {
+                    "rpm_manifest": {
+                        "data": {
+                            "rpms": [
+                                {
+                                    "srpm_name": "openssl",
+                                    "srpm_nevra": "openssl-0:1.2.3-1.src",
+                                    "name": "openssl",
+                                    "nvra": "openssl-1.2.3-1.ppc64le"
+                                },
+                                {
+                                    "srpm_name": "tespackage",
+                                    "srpm_nevra": "testpackage-10:1.2.3-1.src",
+                                    "name": "tespackage",
+                                    "nvra": "testpackage-1.2.3-1.ppc64le"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parent_brew_build": "bar-parent-container-1-10",
+                "parsed_data": {
+                    "files": [
+                        {
+                            "key": "buildfile",
+                            "content_url": "http://git.repo.com/cgit/rpms/bar-container/plain/Dockerfile?id=commit_hash2",
+                            "filename": u"Dockerfile"
+                        }
+                    ],
+                },
+                "repositories": [
+                    {
+                        "published": True,
+                        "registry": "registry.example.com",
+                        "repository": "foobar-product/bar",
+                        "tags": [{"name": "latest"}],
+                    }
+                ],
+            },
+        ]
+
+        self.fake_pyxis_find_images_by_nvr = {
+            "find_images_by_nvr": {
+                "data": foo_image_1_20_data,
+                "error": None,
+                "page": 0,
+                "page_size": 250,
+                "total": 2,
+            }
+        }
+
+        self.fake_pyxis_find_images_by_nvr_parent = {
+            "find_images_by_nvr": {
+                "data": foo_parent_image_2_130_data,
+                "error": None,
+                "page": 0,
+                "page_size": 250,
+                "total": 2,
+            }
+        }
+
+        self.fake_pyxis_find_images_by_nvrs = {
+            "find_images": {
+                "data": foo_image_1_20_data + bar_image_2_30_data,
+                "error": None,
+                "page": 0,
+                "page_size": 250,
+                "total": 4,
+            }
+        }
+
         self.fake_images_with_parsed_data = [
             {
                 'brew': {
@@ -1381,12 +1664,12 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         self.assertEqual(ret[0]["release_categories"], ["Beta"])
 
     @patch('freshmaker.lightblue.ContainerImage.resolve_published')
-    @patch('freshmaker.lightblue.LightBlue.find_container_images')
+    @patch('freshmaker.pyxis_gql.Client')
     @patch('os.path.exists')
     @patch('freshmaker.kojiservice.KojiService.get_build')
     @patch('freshmaker.kojiservice.KojiService.get_task_request')
     def test_parent_images_with_package(
-            self, get_task_request, get_build, exists, cont_images,
+            self, get_task_request, get_build, exists, gql_client,
             resolve_published):
 
         get_build.return_value = {"task_id": 123456}
@@ -1394,16 +1677,7 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             "git://example.com/rpms/repo-1#commit_hash1", "target1", {}]
         exists.return_value = True
 
-        # Test that even when the parent image does not have the repositories
-        # set, it will take the content_sets from the child image.
-        images_without_repositories = []
-        for data in self.fake_images_with_parsed_data:
-            img = ContainerImage.create(data)
-            del img["repositories"]
-            images_without_repositories.append(img)
-
-        cont_images.side_effect = [images_without_repositories, [],
-                                   images_without_repositories]
+        gql_client.return_value.execute.return_value = self.fake_pyxis_find_images_by_nvr_parent
 
         lb = LightBlue(server_url=self.fake_server_url,
                        cert=self.fake_cert_file,
@@ -1412,35 +1686,27 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
             self.fake_container_images[0], "openssl")
 
         self.assertEqual(1, len(ret))
-        self.assertEqual(ret[0]["brew"]["package"], "package-name-1")
+        self.assertEqual(ret[0]["brew"]["build"], "foo-parent-container-2-130")
         self.assertEqual(set(ret[0]["content_sets"]),
-                         set(["dummy-content-set-1", "dummy-content-set-2"]))
+                         set(["foo-content-set-x86_64", "foo-content-set-ppc64le"]))
 
     @patch('freshmaker.lightblue.ContainerImage.resolve_published')
-    @patch('freshmaker.lightblue.LightBlue.find_container_images')
+    @patch('freshmaker.pyxis_gql.Client')
     @patch('os.path.exists')
     @patch('freshmaker.kojiservice.KojiService.get_build')
     @patch('freshmaker.kojiservice.KojiService.get_task_request')
     def test_parent_images_with_package_last_parent_content_sets(
-            self, get_task_request, get_build, exists, cont_images,
+            self, get_task_request, get_build, exists, gql_client,
             resolve_published):
         get_build.return_value = {"task_id": 123456}
         get_task_request.return_value = [
             "git://example.com/rpms/repo-1#commit_hash1", "target1", {}]
         exists.return_value = True
 
-        # Test that even when the parent image does not have the repositories
-        # set, it will take the content_sets from the child image.
-        images_without_repositories = []
-        for data in self.fake_images_with_parsed_data:
-            img = ContainerImage.create(data)
-            del img["repositories"]
-            images_without_repositories.append(img)
-
-        cont_images.side_effect = [self.fake_container_images,
-                                   images_without_repositories,
-                                   images_without_repositories, [],
-                                   images_without_repositories]
+        gql_client.return_value.execute.side_effect = [
+            self.fake_pyxis_find_images_by_nvr,
+            self.fake_pyxis_find_images_by_nvr_parent,
+        ]
 
         lb = LightBlue(server_url=self.fake_server_url,
                        cert=self.fake_cert_file,
@@ -1448,14 +1714,13 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
         ret = lb.find_parent_images_with_package(
             self.fake_container_images[0], "openssl", [])
 
-        self.assertEqual(3, len(ret))
-        self.assertEqual(ret[0]["brew"]["package"], "package-name-1")
+        self.assertEqual(2, len(ret))
+        self.assertEqual(ret[0]["brew"]["build"], "foo-container-1-20")
+        self.assertEqual(ret[1]["brew"]["build"], "foo-parent-container-2-130")
         self.assertEqual(set(ret[0]["content_sets"]),
-                         set(['dummy-content-set-1', 'dummy-content-set-2']))
+                         set(["foo-content-set-x86_64", "foo-content-set-ppc64le"]))
         self.assertEqual(set(ret[1]["content_sets"]),
-                         set(['dummy-content-set-1', 'dummy-content-set-2']))
-        self.assertEqual(set(ret[2]["content_sets"]),
-                         set(['dummy-content-set-1', 'dummy-content-set-2']))
+                         set(["foo-content-set-x86_64", "foo-content-set-ppc64le"]))
 
     @patch('freshmaker.lightblue.LightBlue.find_images_with_packages_from_content_set')
     @patch('freshmaker.lightblue.LightBlue.find_parent_images_with_package')
@@ -2035,126 +2300,66 @@ class TestQueryEntityFromLightBlue(helpers.FreshmakerTestCase):
 
     @patch('freshmaker.lightblue.ContainerImage.resolve')
     @patch('freshmaker.pyxis_gql.Client')
-    @patch('freshmaker.lightblue.LightBlue.find_container_images')
     @patch('os.path.exists')
     def test_images_with_content_set_packages_leaf_container_images(
-        self, exists, cont_images, gql_client, resolve
+        self, exists, gql_client, resolve
     ):
         exists.return_value = True
-        cont_images.return_value = self.fake_container_images
-        gql_client.return_value.execute.return_value = self.fake_pyxis_find_repos
+        gql_client.return_value.execute.side_effect = [
+            self.fake_pyxis_find_repos,
+            self.fake_pyxis_find_images_by_nvrs
+        ]
 
         lb = LightBlue(server_url=self.fake_server_url,
                        cert=self.fake_cert_file,
                        private_key=self.fake_private_key)
-        lb.find_images_with_packages_from_content_set(
-            ["openssl-1.2.3-2"], ["dummy-content-set"],
-            leaf_container_images=["foo", "bar"])
-        cont_images.assert_called_once_with(
-            {'query': {
-                '$and': [
-                    {'field': 'brew.build', 'values': ['foo', 'bar'], 'op': '$in'},
-                    {'field': 'content_sets.*', 'values': ['dummy-content-set'], 'op': '$in'},
-                    {'field': 'rpm_manifest.*.rpms.*.name', 'values': ['openssl'], 'op': '$in'},
-                ]},
-             'projection': [{'field': 'brew', 'include': True, 'recursive': True},
-                            {'field': 'parsed_data.files', 'include': True, 'recursive': True},
-                            {'field': 'parsed_data.labels.*', 'include': True, 'recursive': True},
-                            {'field': 'parsed_data.layers.*', 'include': True, 'recursive': True},
-                            {'field': 'repositories.*.published', 'include': True, 'recursive': True},
-                            {'field': 'repositories.*.registry', 'include': True, 'recursive': True},
-                            {'field': 'repositories.*.repository', 'include': True, 'recursive': True},
-                            {'field': 'repositories.*.tags.*.name', 'include': True, 'recursive': True},
-                            {'field': 'content_sets', 'include': True, 'recursive': True},
-                            {'field': 'parent_brew_build', 'include': True, 'recursive': False},
-                            {'field': 'architecture', 'include': True, 'recursive': False},
-                            {'field': 'rpm_manifest.*.rpms.*.srpm_nevra', 'include': True, 'recursive': True},
-                            {'field': 'rpm_manifest.*.rpms.*.nvra', 'include': True, 'recursive': True},
-                            {'field': 'rpm_manifest.*.rpms.*.name', 'include': True, 'recursive': True},
-                            {'field': 'rpm_manifest.*.rpms.*.srpm_name', 'include': True, 'recursive': True}],
-             'objectType': 'containerImage'})
+        images = lb.find_images_with_packages_from_content_set(
+            ["openssl-1.2.3-2"], ["foo-content-set-x86_64", "foo-content-set-ppc64le"],
+            leaf_container_images=["foo-container-1-20", "bar-container-2-30"]
+        )
+
+        # Only foo-container-1-20 has the content sets enabled
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0].nvr, "foo-container-1-20")
 
     @patch('freshmaker.pyxis_gql.Client')
-    @patch('freshmaker.lightblue.LightBlue.find_repositories')
-    @patch('freshmaker.lightblue.LightBlue.find_container_images')
     @patch('freshmaker.kojiservice.KojiService.get_build')
     @patch('freshmaker.kojiservice.KojiService.get_task_request')
     def test_content_sets_of_multiarch_images_to_rebuild(
-            self, koji_task_request, koji_get_build, find_images, find_repos, gql_client):
-        new_images = [
-            {
-                'brew': {
-                    'completion_date': u'20170421T04:27:51.000-0400',
-                    'build': 'build1-name-1.1',
-                    'package': 'package-name-3'
-                },
-                "content_sets": ["content-set-1",
-                                 "content-set-2"],
-                'parent_brew_build': 'some-original-nvr-7.6-252.1561619826',
-                'repositories': [
-                    {'repository': 'product1/repo1', 'published': True,
-                     'tags': [{"name": "latest"}]}
-                ],
-                'rpm_manifest': [{
-                    'rpms': [
-                        {
-                            "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src",
-                            "name": "openssl",
-                            "nvra": "openssl-1.2.3-1.amd64"
-                        }
-                    ]
-                }],
-                'architecture': 'amd64'
-            },
-            {
-                'brew': {
-                    'completion_date': u'20170421T04:27:51.000-0400',
-                    'build': 'build1-name-1.1',
-                    'package': 'package-name-4'
-                },
-                "content_sets": ["content-set-2",
-                                 "content-set-3"],
-                'parent_brew_build': 'some-original-nvr-7.6-252.1561619826',
-                'repositories': [
-                    {'repository': 'product1/repo1', 'published': True,
-                     'tags': [{"name": "latest"}]}
-                ],
-                'rpm_manifest': [{
-                    'rpms': [
-                        {
-                            "srpm_name": "openssl",
-                            "srpm_nevra": "openssl-0:1.2.3-1.src",
-                            "name": "openssl",
-                            "nvra": "openssl-1.2.3-1.s390x"
-                        }
-                    ]
-                }],
-                'architecture': 's390x'
-            }
-        ]
+            self, koji_task_request, koji_get_build, gql_client):
 
-        gql_client.return_value.execute.return_value = self.fake_pyxis_find_repos
-        new_images = [ContainerImage.create(i) for i in new_images]
-        find_images.return_value = self.fake_container_images + new_images
+        gql_client.return_value.execute.side_effect = [
+            self.fake_pyxis_find_repos,
+            self.fake_pyxis_find_images_by_nvrs,
+        ]
         koji_task_request.side_effect = self.fake_koji_task_requests
         koji_get_build.side_effect = self.fake_koji_builds
-        right_content_sets = [["dummy-content-set-1", "dummy-content-set-2"],
-                              ["dummy-content-set-1"],
-                              ["content-set-1", "content-set-2"],
-                              ["content-set-2", "content-set-3"]]
+
         with patch('os.path.exists'):
             lb = LightBlue(server_url=self.fake_server_url,
                            cert=self.fake_cert_file,
                            private_key=self.fake_private_key)
             ret = lb.find_images_with_packages_from_content_set(
                 set(["openssl-1.2.3-3"]),
-                ["content-set-1", "content-set-2", "content-set-3"],
-                leaf_container_images=['placeholder'])
+                [
+                    "foo-content-set-x86_64",
+                    "foo-content-set-ppc64le",
+                    "bar-content-set-x86_64",
+                    "bar-content-set-ppc64le",
+                ],
+                leaf_container_images=["foo-container-1-20", "bar-container-2-30"])
 
-        self.assertEqual(4, len(ret))
-        images_content_sets = [sorted(i.get('content_sets', ['!'])) for i in ret]
-        self.assertEqual(images_content_sets, right_content_sets)
+        self.assertEqual(2, len(ret))
+        foo_container = [x for x in ret if x.nvr == "foo-container-1-20"][0]
+        bar_container = [x for x in ret if x.nvr == "bar-container-2-30"][0]
+        self.assertEqual(
+            sorted(foo_container["content_sets"]),
+            ["foo-content-set-ppc64le", "foo-content-set-x86_64"]
+        )
+        self.assertEqual(
+            sorted(bar_container["content_sets"]),
+            ["bar-content-set-ppc64le", "bar-content-set-x86_64"]
+        )
 
     @patch('freshmaker.lightblue.LightBlue.find_container_images')
     @patch('os.path.exists')

--- a/tests/test_pyxis_gql.py
+++ b/tests/test_pyxis_gql.py
@@ -48,20 +48,20 @@ def test_pyxis_graphql_find_repositories():
             "data": [
                 {
                     "auto_rebuild_tags": ["latest"],
-                    "registry": "registry.example.com",
+                    "published": True,
                     "release_categories": ["Generally Available"],
                     "repository": "foobar/foo",
                 },
                 {
                     "auto_rebuild_tags": ["latest"],
-                    "registry": "registry.example.com",
+                    "published": True,
                     "release_categories": ["Generally Available"],
                     "repository": "foobar/bar",
                 },
             ],
             "error": None,
             "page": 0,
-            "page_size": 50,
+            "page_size": 250,
             "total": 2,
         }
     }
@@ -91,7 +91,7 @@ def test_pyxis_graphql_get_repository_by_registry_path():
         "get_repository_by_registry_path": {
             "data": {
                 "auto_rebuild_tags": ["1.0", "1.1"],
-                "registry": "registry.example.com",
+                "published": True,
                 "release_categories": ["Generally " "Available"],
                 "repository": "foobar/foobar-operator",
             },
@@ -197,7 +197,7 @@ def test_pyxis_graphql_find_images_by_installed_rpms():
             ],
             "error": None,
             "page": 0,
-            "page_size": 50,
+            "page_size": 250,
             "total": 2,
         }
     }
@@ -309,7 +309,7 @@ def test_pyxis_graphql_find_images_by_nvr():
             ],
             "error": None,
             "page": 0,
-            "page_size": 50,
+            "page_size": 250,
             "total": 2,
         }
     }
@@ -397,7 +397,7 @@ def test_pyxis_graphql_find_images_by_nvrs():
             ],
             "error": None,
             "page": 0,
-            "page_size": 50,
+            "page_size": 250,
             "total": 2,
         }
     }
@@ -460,7 +460,7 @@ def test_pyxis_graphql_find_images_by_names():
             ],
             "error": None,
             "page": 0,
-            "page_size": 50,
+            "page_size": 250,
             "total": 2,
         }
     }

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = bandit, docs, flake8, mypy, py310
+ignore_base_python_conflict = True
 
 [testenv]
 basepython = python3
@@ -39,6 +40,7 @@ commands =
 basepython = python3
 skip_install = true
 deps = bandit
+allowlist_externals = /bin/bash
 commands =
     ; 0.0.0.0 is set in BaseConfiguration, which is ok for local dev and it
     ; will be replace with a specific host IP when deploy to a server. So, it

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -38,6 +38,5 @@ python3-sqlalchemy
 python3-systemd
 python3-semver
 python3-tabulate
-python3-vcrpy
 python-json-logger
 systemd


### PR DESCRIPTION
The LightBlue class is updated to use Pyxis GraphQL APIs to find
container repositories and images, this is just a partial change so
there are still a lot of variables, functions in this class have not
been changed accordingly.

JIRA: CWFHEALTH-1708
JIRA: CWFHEALTH-1709
JIRA: CWFHEALTH-1710