### PR TITLE
Fix product pages API url

### DIFF
--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -205,7 +205,7 @@ def get_ocp_release_date(ocp_version):
 
     ocp_release = f"openshift-{ocp_version}"
 
-    url = f"{conf.product_pages_api_url.rstrip('/')}/releases/{ocp_release}/schedule-tasks"
+    url = f"{conf.product_pages_api_url.rstrip('/')}/releases/{ocp_release}/schedule-tasks/"
     resp = requests.get(
         url,
         params={"name": "GA", "fields": "name,date_finish"},

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -393,15 +393,15 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
     def test_get_operator_indices_with_unreleased_filtered_out(self, page):
         pp_mock_data = [
             {
-                "url": "http://pp.example.com/api/releases/openshift-4.5/schedule-tasks",
+                "url": "http://pp.example.com/api/releases/openshift-4.5/schedule-tasks/",
                 "json": [{"name": "GA", "date_finish": "2020-02-05"}]
             },
             {
-                "url": "http://pp.example.com/api/releases/openshift-4.6/schedule-tasks",
+                "url": "http://pp.example.com/api/releases/openshift-4.6/schedule-tasks/",
                 "json": [{"name": "GA", "date_finish": "2020-05-23"}]
             },
             {
-                "url": "http://pp.example.com/api/releases/openshift-4.8/schedule-tasks",
+                "url": "http://pp.example.com/api/releases/openshift-4.8/schedule-tasks/",
                 "json": [{"name": "GA", "date_finish": "2021-08-12"}]
             }
         ]


### PR DESCRIPTION
Product pages APIs now requires trailing slash in urls, otherwise the APIs return empty results unless we follow the redirects.
```
$ curl https://<product-pages-url>/pp/api/v1/releases/openshift-4.10/schedule-tasks
<nothing>
    
$ curl https://<product-pages-url>/pp/api/v1/releases/openshift-4.10/schedule-tasks/
<result as expected>
    
$ curl -L https://<product-pages-url>/pp/api/v1/releases/openshift-4.10/schedule-tasks
<result as expected>
```