### PR TITLE
Pull fedora 35 image from fedora registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:35-x86_64
+FROM registry.fedoraproject.org/fedora:35-x86_64
 
 LABEL \
     name="Freshmaker application" \


### PR DESCRIPTION
Fedora 35 image has been removed from quay.io/fedora/fedora, use fedora registry, later we should upgrade to newer version.