### PR TITLE
Fix get product version which doesn't have a GA date

### DIFF
--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -217,6 +217,11 @@ def get_ocp_release_date(ocp_version):
         return None
     if not resp.ok:
         resp.raise_for_status()
+
+    # A new unpublished version can exist without any GA schedule date
+    if not resp.json():
+        return None
+
     return resp.json()[0]['date_finish']
 
 

--- a/tests/test_pyxis.py
+++ b/tests/test_pyxis.py
@@ -403,6 +403,10 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
             {
                 "url": "http://pp.example.com/api/releases/openshift-4.8/schedule-tasks/",
                 "json": [{"name": "GA", "date_finish": "2021-08-12"}]
+            },
+            {
+                "url": "http://pp.example.com/api/releases/openshift-4.9/schedule-tasks/",
+                "json": []
             }
         ]
         page.return_value = self.indices + [
@@ -428,6 +432,7 @@ class TestQueryPyxis(helpers.FreshmakerTestCase):
 
         assert len(indices) == 3
         assert "4.8" not in [i["ocp_version"] for i in indices]
+        assert "4.9" not in [i["ocp_version"] for i in indices]
 
     @patch('freshmaker.pyxis.Pyxis._pagination')
     def test_get_bundles_by_related_image_digest(self, page):


### PR DESCRIPTION
A product version can exist in product pages but doesn't have the GA date, freshmaker should also handle this case.