### PR TITLE
Pyxis kerberos (squashed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ freshmaker.db
 .mypy_cache/
 .dmypy.json
 dmypy.json
+# pyenv/virtualenv
+.python-version

--- a/freshmaker/container.py
+++ b/freshmaker/container.py
@@ -23,7 +23,7 @@ import kobo.rpmlib
 import re
 
 from dataclasses import dataclass, field, fields
-from typing import Any, Dict, List, Optional, Union, Tuple
+from typing import Any, Dict, List, Optional
 
 from freshmaker import conf, log
 from freshmaker.kojiservice import KojiService, KojiLookupError
@@ -322,8 +322,8 @@ class Container:
 
 
 class ContainerAPI:
-    def __init__(self, pyxis_graphql_url: str, pyxis_cert: Union[str, Tuple[str]]):
-        self.pyxis = PyxisGQL(url=pyxis_graphql_url, cert=pyxis_cert)
+    def __init__(self, pyxis_graphql_url: str):
+        self.pyxis = PyxisGQL(url=pyxis_graphql_url)
 
     def find_auto_rebuild_containers_with_older_rpms(
         self,

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -195,9 +195,7 @@ def test_find_auto_rebuild_containers_with_older_rpms():
     rpm_nvrs = ["foo-10-123.el8"]
     content_sets = ["rhel-8-for-x86_64-baseos-rpms", "rhel-8-for-aarch64-baseos-rpms"]
 
-    container_api = ContainerAPI(
-        pyxis_graphql_url="graphql.pyxis.local", pyxis_cert=("/path/to/crt", "/path/to/key")
-    )
+    container_api = ContainerAPI(pyxis_graphql_url="graphql.pyxis.local")
     containers = container_api.find_auto_rebuild_containers_with_older_rpms(
         rpm_nvrs=rpm_nvrs, content_sets=content_sets, published=True
     )
@@ -351,7 +349,7 @@ def test_resolve_image_build_metadata():
     ]
     flexmock(KojiService).should_receive("get_task_request").and_return(task_params)
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -533,7 +531,7 @@ def test_resolve_image_compose_sources():
     ]
     flexmock(RetryingODCS).should_receive("get_compose").and_return(odcs_composes).one_by_one()
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -715,9 +713,7 @@ def test_resolve_content_sets():
         odcs_composes
     ).one_by_one()
 
-    pyxis_gql = PyxisGQL(
-        url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key")
-    )
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -900,9 +896,7 @@ def test_resolve_published():
         odcs_composes
     ).one_by_one()
 
-    pyxis_gql = PyxisGQL(
-        url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key")
-    )
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])

--- a/tests/test_pyxis_gql.py
+++ b/tests/test_pyxis_gql.py
@@ -66,7 +66,7 @@ def test_pyxis_graphql_find_repositories():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     repositories = pyxis_gql.find_repositories()
@@ -99,7 +99,7 @@ def test_pyxis_graphql_get_repository_by_registry_path():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     repository = pyxis_gql.get_repository_by_registry_path(
@@ -202,7 +202,7 @@ def test_pyxis_graphql_find_images_by_installed_rpms():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     rpm_names = ["foo"]
@@ -314,7 +314,7 @@ def test_pyxis_graphql_find_images_by_nvr():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
@@ -402,7 +402,7 @@ def test_pyxis_graphql_find_images_by_nvrs():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key"))
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     nvrs = ["foobar-container-v0.13.0-12.1582340001"]
@@ -465,9 +465,7 @@ def test_pyxis_graphql_find_images_by_names():
         }
     }
 
-    pyxis_gql = PyxisGQL(
-        url="graphql.pyxis.local", cert=("/path/to/crt", "/path/to/key")
-    )
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     images = pyxis_gql.find_images_by_names(["foobar-container"])


### PR DESCRIPTION
(This Pull Requests continues #201.)

Pyxis supports authentication through kerberos. This method is preffered over SSL certificates because we won't need to renew our certificates periodically anymore.

This contribution implements kerberos authentication to the pyxis-gql.py module through the requests-kerberos library.

The Jira card associated with this contribution is https://issues.redhat.com/browse/CWFHEALTH-1762
### Testing remarks

I ran all the unit tests successfully. I also made manual e2e tests to make sure all queries were working properly. I used my personal kerberos credentials and send the requests to the dev pyxis gql endpoint.

I called all methods of the PyxisGQL class except for query, _get_repo_projection and _get_image_projection, which are called by the other methods. I ran the other methods just as in the unit tests and most of them returned empty lists as result (since the queried values were just mock values).

The methods find_images_by_nvr and find_repositories returned actual results. find_repositories took a pretty long time, and the result was quite long. I'm quoting an excerpt of the result from find_repositories below:

``` python
[
 ...
 {'auto_rebuild_tags': [],
  'registry': 'registry.access.redhat.com',
  'release_categories': None,
  'repository': 'rhacm2/acm-cluster-templates-rhel8-operator'}
]
```

### Questions

I have removed the `cert` parameter from `PyxisGQL` and `pyxis_cert` from `ContainerAPI`. Although these are silly changes, they are still breaking changes.

Please let me know if you think something will break in production, or you you think we should take a backwards-compatible approach (like accepting the parameters for now, but issuing a deprecation warning).