### PR TITLE
feat: bump fedora version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:35-x86_64
+FROM registry.fedoraproject.org/fedora:37-x86_64
 
 LABEL \
     name="Freshmaker application" \
@@ -7,7 +7,7 @@ LABEL \
 
 
 # Use Copr repo for python3-rhmsg package
-RUN dnf install -y 'dnf-command(copr)' && dnf copr enable -y mikeb/python-rhmsg
+RUN dnf install -y 'dnf-command(copr)' && dnf copr enable -y qwan/python-rhmsg
 
 COPY yum-packages.txt /tmp/yum-packages.txt
 
@@ -24,7 +24,7 @@ RUN \
     echo '' > requirements.txt && \
     pip3 install . --no-deps
 
-RUN pip install jsonformatter==0.3.1
+RUN pip install jsonformatter==0.3.2 gql[requests]==3.3.0
 
 RUN mkdir /var/log/freshmaker/
 

--- a/conf/config.py
+++ b/conf/config.py
@@ -205,7 +205,7 @@ class BaseConfiguration(object):
     }
 
     # repositories that should be searched for unpublished images, specifically because of EUS base images
-    UNPUBLISHED_EXCEPTIONS = []
+    UNPUBLISHED_EXCEPTIONS: list[dict[str, str]] = []
 
 
 class DevConfiguration(BaseConfiguration):

--- a/freshmaker/views.py
+++ b/freshmaker/views.py
@@ -814,7 +814,7 @@ def register_api_v1():
                              view_func=view,
                              **val['options'])
 
-    app.register_blueprint(monitor_api)
+    app.register_blueprint(monitor_api, name="monitor_api_v1")
 
 
 def register_api_v2():
@@ -829,7 +829,7 @@ def register_api_v2():
                              view_func=view,
                              **val['options'])
 
-    app.register_blueprint(monitor_api)
+    app.register_blueprint(monitor_api, name="monitor_api_v2")
 
 
 register_api_v1()

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-jsonformatter==0.3.1
+jsonformatter==0.3.2
     # via -r requirements.in
 kitchen==1.2.6
     # via


### PR DESCRIPTION
The fedora version that FM is using (f35) reached its end of life. Therefore, we need to update it.

I'm editing the old PR text and adding a few remarks. I'll mark them with "**[<ins>new</ins>]**".

List of changes:
- update package jsonformatter
- register api's v1 and v2 with different names in `view.py`
- gql installation through pip during the build process; I believe it is not available through dnf
- type hint in line 208 of `conf/config.py` (it was failing a flake8 check)

Please let me know if any of these are actually unnecessary!


### Remarks about testing

Things that I managed to do:
- I ran unit tests (and tox) locally, all good!
- **[<ins>new</ins>]**  I built the image and deployed it to the dev environment! I also adapted and ran the "dry_run" script and got a good return:
```json
{
    "builds":[],
    "depending_events":[],
    "depends_on_events":[],
    "dry_run":true,
    "event_type_id":13,
    "id":52026,
    "message_id":"manual_rebuild_1678894295.1448815",
    "requested_rebuilds":[],
    "requester":"mfoganho",
    "requester_metadata":{},
    "search_key":"110818",
    "state":0,
    "state_name":"INITIALIZED",
    "state_reason":null,
    "time_created":"2023-03-15T15:31:35Z",
    "time_done":null,
    "url":"/api/1/events/52026"
}
```
- **[<ins>new</ins>]** I left it running for about day and checked the splunk logs, there was no error so far (but also no real rebuild).
- I ran unit tests inside the container. There was one failing test, but that same test was passing when I ran tox in my local codebase. Perhaps it is because I didn't set up the network for the container correctly?
```
================================================================ short test summary info =================================================================
FAILED tests/test_views.py::TestOpenIDCLogin::test_openidc_manual_trigger_unauthorized - AssertionError: '500 INTERNAL SERVER ERROR' != '401 UNAUTHORIZED'
===================================================== 1 failed, 515 passed, 16552 warnings in 19.46s =====================================================
```

### **[<ins>new</ins>]** Questions
- Do you think this enough testing? Should we wait until a rebuild is actually performed? Or, perhaps, trigger one manually?

JIRA: CWFHEALTH-1788