### PR TITLE
Use certificate to authenticate to Pyxis

### DIFF
--- a/freshmaker/container.py
+++ b/freshmaker/container.py
@@ -23,7 +23,7 @@ import kobo.rpmlib
 import re
 
 from dataclasses import dataclass, field, fields
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from freshmaker import conf, log
 from freshmaker.kojiservice import KojiService, KojiLookupError
@@ -322,8 +322,8 @@ class Container:
 
 
 class ContainerAPI:
-    def __init__(self, pyxis_graphql_url: str):
-        self.pyxis = PyxisGQL(url=pyxis_graphql_url)
+    def __init__(self, pyxis_graphql_url: str, cert: Union[str, tuple[str, str]]):
+        self.pyxis = PyxisGQL(url=pyxis_graphql_url, cert=cert)
 
     def find_auto_rebuild_containers_with_older_rpms(
         self,

--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -447,7 +447,10 @@ class PyxisAPI(object):
 
         :param str server_url: Pyxis GraphQL url
         """
-        self.pyxis = PyxisGQL(url=server_url)
+        self.pyxis = PyxisGQL(
+            url=server_url,
+            cert=(conf.pyxis_certificate, conf.pyxis_private_key)
+        )
 
     def _dicts_to_images(self, image_dicts):
         """Convert image dictionaries to list of ContainerImage"""

--- a/freshmaker/image_verifier.py
+++ b/freshmaker/image_verifier.py
@@ -38,7 +38,13 @@ class ImageVerifier(object):
 
         :param PyxisGQL pyxis: PyxisGQL instance to use to verify images.
         """
-        self.pyxis = pyxis if pyxis else PyxisGQL(url=conf.pyxis_server_url)
+        self.pyxis = (
+            pyxis
+            if pyxis
+            else PyxisGQL(
+                url=conf.pyxis_server_url, cert=(conf.pyxis_certificate, conf.pyxis_private_key)
+            )
+        )
 
     def _verify_repository_data(self, repo):
         """

--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -24,7 +24,6 @@ from functools import cached_property
 from gql import Client, gql
 from gql.dsl import DSLQuery, DSLSchema, dsl_gql
 from gql.transport.requests import RequestsHTTPTransport
-from requests_kerberos import OPTIONAL, HTTPKerberosAuth
 
 PYXIS_PAGE_SIZE = 250
 
@@ -34,10 +33,9 @@ class PyxisGQLRequestError(RuntimeError):
 
 
 class PyxisGQL:
-    def __init__(self, url):
+    def __init__(self, url, cert):
         """Create authenticated Pyxis GraphQL session"""
-        pyxis_krb_auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL, force_preemptive=True)
-        transport = RequestsHTTPTransport(url=url, retries=3, auth=pyxis_krb_auth)
+        transport = RequestsHTTPTransport(url=url, cert=cert, retries=3)
 
         # Fetch the schema from the transport using an introspection query
         self._client = Client(transport=transport, fetch_schema_from_transport=True)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -195,7 +195,7 @@ def test_find_auto_rebuild_containers_with_older_rpms():
     rpm_nvrs = ["foo-10-123.el8"]
     content_sets = ["rhel-8-for-x86_64-baseos-rpms", "rhel-8-for-aarch64-baseos-rpms"]
 
-    container_api = ContainerAPI(pyxis_graphql_url="graphql.pyxis.local")
+    container_api = ContainerAPI(pyxis_graphql_url="graphql.pyxis.local", cert="/path/to/cert")
     containers = container_api.find_auto_rebuild_containers_with_older_rpms(
         rpm_nvrs=rpm_nvrs, content_sets=content_sets, published=True
     )
@@ -349,7 +349,7 @@ def test_resolve_image_build_metadata():
     ]
     flexmock(KojiService).should_receive("get_task_request").and_return(task_params)
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -531,7 +531,7 @@ def test_resolve_image_compose_sources():
     ]
     flexmock(RetryingODCS).should_receive("get_compose").and_return(odcs_composes).one_by_one()
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -713,7 +713,7 @@ def test_resolve_content_sets():
         odcs_composes
     ).one_by_one()
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])
@@ -896,7 +896,7 @@ def test_resolve_published():
         odcs_composes
     ).one_by_one()
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
     container = Container.load(images[0])

--- a/tests/test_pyxis_gql.py
+++ b/tests/test_pyxis_gql.py
@@ -66,7 +66,7 @@ def test_pyxis_graphql_find_repositories():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     repositories = pyxis_gql.find_repositories()
@@ -99,7 +99,7 @@ def test_pyxis_graphql_get_repository_by_registry_path():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     repository = pyxis_gql.get_repository_by_registry_path(
@@ -202,7 +202,7 @@ def test_pyxis_graphql_find_images_by_installed_rpms():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     rpm_names = ["foo"]
@@ -314,7 +314,7 @@ def test_pyxis_graphql_find_images_by_nvr():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
@@ -402,7 +402,7 @@ def test_pyxis_graphql_find_images_by_nvrs():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     nvrs = ["foobar-container-v0.13.0-12.1582340001"]
@@ -465,7 +465,7 @@ def test_pyxis_graphql_find_images_by_names():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     images = pyxis_gql.find_images_by_names(["foobar-container"])
@@ -525,7 +525,7 @@ def test_pyxis_graphql_find_images_by_name_version():
         }
     }
 
-    pyxis_gql = PyxisGQL(url="graphql.pyxis.local")
+    pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
     images = pyxis_gql.find_images_by_name_version("foobar-container", "v0.13.0", published=True, content_sets=["rhel-8-for-x86_64-baseos-rpms"])


### PR DESCRIPTION
When use kerberos to authenticate to Pyxis, Pyxis doesn't return rpm_manifrest edges for image query APIs (JIRA: ISV-1957), so switch back to certificate authentication. The implementation of the certificate authentication has some changes, so instead of reverting f5ad1c2, this new commit is added.