### PR TITLE
Fix get published fixed image

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -1453,7 +1453,7 @@ class PyxisAPI(object):
         rpm_name_to_nvrs = {kobo.rpmlib.parse_nvr(nvr)["name"]: nvr for nvr in rpm_nvrs}
 
         images = self.pyxis.find_images_by_name_version(
-            name, version, content_sets
+            name, version, published=True, content_sets=content_sets
         )
         if not images:
             log.error("Could not find an image with the name and version of %s-%s", name, version)

--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -611,7 +611,7 @@ class PyxisGQL:
 
         ds = self.dsl_schema
         page_num = 0
-        page_size = 50
+        page_size = PYXIS_PAGE_SIZE
 
         while True:
             query_dsl = ds.Query.find_images(


### PR DESCRIPTION
1. When find images by name and version to get published images, should query for published images only.
2. Update Pyxis result page size to our default value