### PR TITLE
feat: rename default branch do "main"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Disable Jekyll
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         shell: bash
         run: mkdir -p docs/_build/html/ && touch docs/_build/html/.nojekyll
 
@@ -33,7 +33,7 @@ jobs:
           tox_env: docs
 
       - name: Deploy docs
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           branch: gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -17,6 +17,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Execute tests
         uses: ./.github/actions/tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,12 @@ try { // massive try{} catch{} around the entire build for failure notifications
                 // get git commit short SHA, we'll tag image with this SHA value later
                 commitid = sh(returnStdout: true, script: """printf `git rev-parse --short HEAD`""").trim()
 
-                scmVars.GIT_BRANCH_NAME = scmVars.GIT_BRANCH.split('/')[-1]  // origin/master -> master
+                scmVars.GIT_BRANCH_NAME = scmVars.GIT_BRANCH.split('/')[-1]  // origin/main -> main
                 def branch = scmVars.GIT_BRANCH_NAME
-                if ( branch == 'master' ) {
-                    echo 'Building master'
+                if ( branch == 'main' ) {
+                    echo 'Building main'
                     // setting build display name
-                    currentBuild.displayName = 'master'
+                    currentBuild.displayName = 'main'
                 }
             }
             stage('Build Docker container') {
@@ -53,7 +53,7 @@ try { // massive try{} catch{} around the entire build for failure notifications
             }
         }
         node('docker') {
-            if (scmVars.GIT_BRANCH == 'origin/master') {
+            if (scmVars.GIT_BRANCH == 'origin/main') {
                 stage('Tag "latest".') {
                     checkout scm
                     docker.withRegistry(
@@ -93,7 +93,7 @@ try { // massive try{} catch{} around the entire build for failure notifications
     }
 
     def RECIEPENT = scmVars.GIT_AUTHOR_EMAIL
-    if (ownership.job.ownershipEnabled && branch == 'master') {
+    if (ownership.job.ownershipEnabled && branch == 'main') {
         RECIEPENT = ownership.job.primaryOwnerEmail
     }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Freshmaker-status](https://quay.io/repository/factory2/freshmaker/status)](https://quay.io/repository/factory2/freshmaker)
-![Freshmaker](https://github.com/redhat-exd-rebuilds/freshmaker/raw/master/logo.png)
+![Freshmaker](https://github.com/redhat-exd-rebuilds/freshmaker/raw/main/logo.png)
 
 ## What is Freshmaker?
 

--- a/docs/db.rst
+++ b/docs/db.rst
@@ -55,7 +55,7 @@ Database Migrations
 Migration is similar to `Cachito <https://github.com/release-engineering/cachito>`_.
 Follow the steps below for database data and/or schema migrations:
 
-* Checkout the master branch and ensure no schema changes are present in ``freshmaker/models.py``
+* Checkout the main branch and ensure no schema changes are present in ``freshmaker/models.py``
 
 * Set ``SQLALCHEMY_DATABASE_URI`` to ``sqlite:///*path-to-your-freshmaker.db*`` in used configuration file.
 

--- a/freshmaker/views.py
+++ b/freshmaker/views.py
@@ -590,7 +590,7 @@ class AsyncBuildAPI(MethodView):
             Content-Type: application/json
 
             {
-                "dist_git_branch": "master",
+                "dist_git_branch": "main",
                 "container_images": ["foo-1-1"]
             }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ defusedxml==0.7.1
     # via -r requirements.in
 dogpile-cache==1.1.3
     # via -r requirements.in
-fedmsg==1.1.2
+fedmsg==1.1.3
     # via -r requirements.in
 flask==2.0.1
     # via
@@ -63,9 +63,9 @@ gql[requests]==3.3.0
     # via -r requirements.in
 graphql-core==3.2.1
     # via gql
-greenlet==1.1.2
+greenlet==2.0.2
     # via sqlalchemy
-gssapi==1.7.3
+gssapi==1.8.2
     # via requests-gssapi
 httplib2==0.20.2
     # via
@@ -165,7 +165,7 @@ python-ldap==3.4.3
     #   pyldap
 pytz==2022.1
     # via moksha-common
-pyzmq==23.0.0
+pyzmq==23.2.1
     # via
     #   fedmsg
     #   moksha-hub
@@ -190,7 +190,7 @@ requests-kerberos==0.12.0
     #   odcs
 requests-toolbelt==0.9.1
     # via gql
-rpm-py-installer==1.1.0
+rpm-py-installer==1.2.0
     # via -r requirements.in
 semver==2.13.0
     # via -r requirements.in
@@ -237,7 +237,7 @@ werkzeug==2.0.1
     # via
     #   -r requirements.in
     #   flask
-yarl==1.7.2
+yarl==1.8.2
     # via gql
 zope-interface==5.4.0
     # via twisted

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = bandit, docs, flake8, mypy, py310
+envlist = bandit, docs, flake8, mypy, py311
 
 [testenv]
 basepython = python3
@@ -29,11 +29,10 @@ commands = flake8
 
 [testenv:mypy]
 description = type check
-# Pin to an older version of mypy since 0.902 does not seem to ignore missing imports
 deps =
-    mypy==0.812
+    mypy==1.1.1
 commands =
-        mypy --ignore-missing-imports --exclude freshmaker/migrations freshmaker tests
+    mypy --ignore-missing-imports --exclude freshmaker/migrations freshmaker tests --install-types --non-interactive
 
 [testenv:bandit]
 basepython = python3


### PR DESCRIPTION
In order to eradicate problematic language, we should rename our default branch to "main" instead of "master".

This PR changes the occurrences of "master" to "main" in a few files, so we can rename the default branch of our repo accordingly. These occurrences are mainly paths and action triggers.

Some occurrences are not relative to our repo (for what I figured), and were left as-is.


### Questions
I would like to ask you, reviewers, the following:
- do you think something is missing?
- do you think some change is unnecessary?

Please let me know your thoughts!


### Migration plan
**[EDIT]** I deleted the 'main' branch I previously created in the Freshmaker upstream repo. I'll follow Qixiang's suggestion and just rename the 'master' branch once everything is ready. The steps will be simpler in this approach:
- merge the changes to the 'master' branch upstream
- rename the 'master' branch to 'main' with the github interface


Please let me know if you think something won't work or is missing!


JIRA: CWF-1799