### PR TITLE
fix(CI-docs): Allow more dep. repos in tox step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build docs
         uses: fedora-python/tox-github-action@master
         with:
-          dnf_install: --repo fedora ${{ steps.packages.outputs.packages }}
+          dnf_install: ${{ steps.packages.outputs.packages }}
           tox_env: docs
 
       - name: Deploy docs


### PR DESCRIPTION
The docs buliding action was failing, apparently because some dependencies were not available in the 'fedora' repo, to which the tox action step was restricted. It would fail because of unprovided dependencies.

Removing the restriction of using only the 'fedora' repo in the tox step solved this problem.

### Testing remarks
- I ran the docs job with act locally, it worked fine!
- I also ran the workflow in my fork. Both the doc building and the doc deployment worked fine there, as well!
    - you can see the job status in the action page: https://github.com/FernandesMF/freshmaker/actions/runs/4556545982/jobs/8037038631
    - also you can see the deployed documentation in the 'gh-pages' branch: https://github.com/FernandesMF/freshmaker/tree/gh-pages

### Question
I wanted to check with you if this approach is fine.

I thought there wouldn't be any problems, since we are not adding any new dependency repo besides those that already come in the image.

But please, let me know if you see any risk or any reason that this would be problematic!


JIRA: CWFHEALTH-1858