### PR TITLE
Keep olm.substitutesFor from original image

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,4 +81,4 @@ html_static_path = []
 htmlhelp_basename = 'Freshmakerdoc'
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': 'python-intersphinx.inv'}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', 'python-intersphinx.inv')}

--- a/freshmaker/kojiservice.py
+++ b/freshmaker/kojiservice.py
@@ -367,6 +367,7 @@ class KojiService(object):
         return ocp_versions_range
 
     @freshmaker.utils.retry(wait_on=(requests.Timeout, requests.ConnectionError), logger=log)
+    @region.cache_on_arguments()
     def get_bundle_csv(self, build_nvr):
         """
         Return CSV(cluster service version) data of operator bundle build

--- a/tests/handlers/botas/test_botas_shipped_advisory.py
+++ b/tests/handlers/botas/test_botas_shipped_advisory.py
@@ -1055,7 +1055,7 @@ def test_get_csv_name():
 def test_get_csv_updates(mock_grbv, mock_gcn):
     mock_grbv.return_value = ("1.2.3+0.1608854400.p", "0.1608854400.p")
     mock_gcn.return_value = "amq-streams.1.2.3-0.1608854400.p"
-    rv = HandleBotasAdvisory._get_csv_updates("amq-streams.1.2.3", "1.2.3")
+    rv = HandleBotasAdvisory._get_csv_updates("amq-streams.1.2.3", "1.2.3", "amq-streams.1.2.3")
     assert rv == {
         "update": {
             "metadata": {
@@ -1074,7 +1074,7 @@ def test_get_csv_updates(mock_grbv, mock_gcn):
 def test_get_csv_updates_without_olm_substitutes(mock_grbv, mock_gcn):
     mock_grbv.return_value = ("1.2.3+0.1608854400.p", "0.1608854400.p")
     mock_gcn.return_value = "amq-streams.1.2.3-0.1608854400.p"
-    rv = HandleBotasAdvisory._get_csv_updates("amq-streams.1.2.3", "1.2.3", olm_substitutes=False)
+    rv = HandleBotasAdvisory._get_csv_updates("amq-streams.1.2.3", "1.2.3")
     assert rv == {
         "update": {
             "metadata": {


### PR DESCRIPTION
When original image has `olm.substitutesFor` annotation, in most cases it was added by Freshmaker with the `operator_csv_modifications_url` in build task parameters, it's not in any file from dist-git repo, when Freshmaker rebuild this image and don't add any new `olm.substitutesFor` annotation, the `olm.substitutesFor` annotation in original image will be lost, this is wrong.

JIRA: CWFHEALTH-2003