### PR TITLE
Certificate-based authentication for Pulp

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -311,14 +311,14 @@ class Config(object):
             'type': str,
             'default': '',
             'desc': 'Server URL of Pulp.'},
-        'pulp_username': {
+        'pulp_crt_path': {
             'type': str,
             'default': '',
-            'desc': 'Username to login Pulp.'},
-        'pulp_password': {
+            'desc': 'Path to certificate file to authenticate to Pulp.'},
+        'pulp_key_path': {
             'type': str,
             'default': '',
-            'desc': 'Password to login Pulp.'},
+            'desc': 'Path to key file to authenticate to Pulp.'},
         'odcs_server_url': {
             'type': str,
             'default': '',

--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -405,9 +405,9 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
         # up eventually when advisories are shipped.
         pulp_repo_ids = list(set(errata.get_pulp_repository_ids(errata_id)))
 
-        pulp = Pulp(server_url=conf.pulp_server_url,
-                    username=conf.pulp_username,
-                    password=conf.pulp_password)
+        pulp = Pulp(
+            server_url=conf.pulp_server_url, cert=(conf.pulp_crt_path, conf.pulp_key_path)
+        )
         content_sets = pulp.get_content_set_by_repo_ids(pulp_repo_ids)
         # Some container builds declare Pulp repos directly instead of content
         # sets, but they are stored in the same location as content sets so they

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -37,8 +37,7 @@ class TestPulp(helpers.FreshmakerTestCase):
     def setUp(self):
         super(TestPulp, self).setUp()
         self.server_url = 'http://localhost/'
-        self.username = 'qa'
-        self.password = 'qa'
+        self.cert = ("path/to/crt", "path/to/key")
 
     @patch('freshmaker.pulp.requests.post')
     def test_query_content_set_by_repo_ids(self, post):
@@ -77,7 +76,7 @@ class TestPulp(helpers.FreshmakerTestCase):
             }
         ]
 
-        pulp = Pulp(self.server_url, username=self.username, password=self.password)
+        pulp = Pulp(self.server_url, cert=self.cert)
         repo_ids = [
             'rhel-7-hpc-node-rpms__7ComputeNode__x86_64',
             'rhel-7-workstation-rpms__7Workstation__x86_64',
@@ -95,7 +94,7 @@ class TestPulp(helpers.FreshmakerTestCase):
                     'fields': ['notes'],
                 }
             }),
-            auth=(self.username, self.password),
+            cert=self.cert,
             timeout=conf.requests_timeout)
 
         self.assertEqual(
@@ -139,7 +138,7 @@ class TestPulp(helpers.FreshmakerTestCase):
             }
         ]
 
-        pulp = Pulp(self.server_url, username=self.username, password=self.password)
+        pulp = Pulp(self.server_url, cert=self.cert)
         repo_ids = [
             'rhel-7-hpc-node-rpms__7ComputeNode__x86_64',
             'rhel-7-workstation-rpms__7Workstation__x86_64',
@@ -157,7 +156,7 @@ class TestPulp(helpers.FreshmakerTestCase):
                     'fields': ['notes'],
                 }
             }),
-            auth=(self.username, self.password),
+            cert=self.cert,
             timeout=conf.requests_timeout)
 
         self.assertEqual(['rhel-7-workstation-rpms', 'rhel-7-desktop-rpms'],
@@ -175,13 +174,13 @@ class TestPulp(helpers.FreshmakerTestCase):
             ]
         }
 
-        pulp = Pulp(self.server_url, username=self.username, password=self.password)
+        pulp = Pulp(self.server_url, cert=self.cert)
         repo_name = pulp.get_docker_repository_name("foo-526")
 
         get.assert_called_once_with(
             '{}pulp/api/v2/repositories/foo-526/'.format(self.server_url),
             params={"distributors": True},
-            auth=(self.username, self.password),
+            cert=self.cert,
             timeout=conf.requests_timeout)
 
         self.assertEqual(repo_name, "scl/foo-526")
@@ -192,8 +191,7 @@ class TestPulp(helpers.FreshmakerTestCase):
         get.side_effect = exceptions.HTTPError("Connection error: get")
         post.side_effect = exceptions.HTTPError("Connection error: post")
 
-        pulp = Pulp(self.server_url, username=self.username,
-                    password=self.password)
+        pulp = Pulp(self.server_url, cert=self.cert)
 
         with self.assertRaises(exceptions.HTTPError):
             pulp.get_docker_repository_name("test")


### PR DESCRIPTION
Pulp is deprecating user/password authentication, and switching to certificate-based auth instead.

This commit:
- implements the change in the authentication method in the pulp module
- updates unit tests for teh pulp module
- fixes a call in `freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py`
- substitutes the credential templates in `freshmaker/config.py`

JIRA: CWFHEALTH-2004

#### Testing remarks
I have been able to test the access of our certificates to the Pulp API, and also the updated authentication method in the Pulp requests:
- I ran the curl command the Pulp team suggested in their documentation page and checked that the certificates (both dev and prod) are working fine
- I made a script and called the Pulp class and its post method (using the dev certificates), it also worked fine.

However, I have not been able to check if the new credentials are being served correctly.