### PR TITLE
Make page_size in Pyxis requests configurable

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -398,6 +398,16 @@ class Config(object):
             'default': [],
             'desc': 'Query Pyxis for index images only with these organizations'
         },
+        'pyxis_default_page_size': {
+            'type': int,
+            'default': 200,
+            'desc': 'Default page size to be used in Pyxis requests'
+        },
+        'pyxis_small_page_size': {
+            'type': int,
+            'default': 50,
+            'desc': 'Small page size to be used in Pyxis requests'
+        },
         'product_pages_api_url': {
             'type': str,
             'default': '',

--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -29,8 +29,6 @@ from gql.transport.requests import RequestsHTTPTransport
 
 from freshmaker import conf
 
-PYXIS_PAGE_SIZE = 200
-
 
 class PyxisGQLRequestError(RuntimeError):
     pass
@@ -160,7 +158,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -213,7 +211,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -273,7 +271,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -342,7 +340,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_images_by_nvr(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 nvr=nvr,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -387,7 +385,7 @@ class PyxisGQL:
             query_filter = {"brew": {"build": {"in": nvrs}}}
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -457,11 +455,14 @@ class PyxisGQL:
         ds = self.dsl_schema
         page_num = 0
 
+        # This query is resource consuming and Pyxis may not be able to handle it in a time
+        # manner when the page_size is large, use the configured small page size to avoid errors.
+
         # Iterate all pages
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_small_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -520,7 +521,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -579,7 +580,7 @@ class PyxisGQL:
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(

--- a/freshmaker/pyxis_gql_async.py
+++ b/freshmaker/pyxis_gql_async.py
@@ -29,8 +29,9 @@ from gql.dsl import DSLField, DSLQuery, DSLSchema, dsl_gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import ExecutionResult
 
+from freshmaker import conf
+
 ASYNCIO_TIMEOUT_S = 5 * 60
-PYXIS_PAGE_SIZE = 250
 
 # TODO implement caching with an async-friendly lib (e.g. https://github.com/aio-libs/aiocache)
 # TODO implement backoffs to handle retries (see backoff module: https://github.com/litl/backoff)
@@ -190,7 +191,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -241,7 +242,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -302,7 +303,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_repositories(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerRepositoryPaginatedResponse.error.select(
@@ -373,7 +374,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_images_by_nvr(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 nvr=nvr,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -419,7 +420,7 @@ class PyxisAsyncGQL:
             query_filter = {"brew": {"build": {"in": nvrs}}}
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -493,11 +494,14 @@ class PyxisAsyncGQL:
         ds = self.dsl_schema
         page_num = 0
 
+        # This query is resource consuming and Pyxis may not be able to handle it in a time
+        # manner when the page_size is large, use the configured small page size to avoid errors.
+
         # Iterate all pages
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_small_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -555,7 +559,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -616,7 +620,7 @@ class PyxisAsyncGQL:
         while True:
             query_dsl = ds.Query.find_images(
                 page=page_num,
-                page_size=PYXIS_PAGE_SIZE,
+                page_size=conf.pyxis_default_page_size,
                 filter=query_filter,
             ).select(
                 ds.ContainerImagePaginatedResponse.error.select(
@@ -682,7 +686,7 @@ class PyxisAsyncGQL:
 
         ds = self.dsl_schema
         page_num = 0
-        page_size = PYXIS_PAGE_SIZE
+        page_size = conf.pyxis_default_page_size
 
         while True:
             query_dsl = ds.Query.find_images(


### PR DESCRIPTION
Introduced two config variables:

1. pyxis_default_page_size
2. pyxis_small_page_size

which can be specified as page_size in Pyxis requests.

Some Pyxis queries are resource consuming and Pyxis may not be able to
handle them in a time manner, use a low number of page_size can help in
such cases.

The resource consuming queries usually have complex search criteria and
Pyxis has to check a lot of entities in backend, or the search hit a
large number of entities in database which is unpredictable at client
side, in such cases, use the pyxis_small_pyxis_size can probably help
Pyxis to handle the request.

The find_images_by_installed_rpms API is one of such queries, so we use
the configured small page_size in this API.