### PR TITLE
Improve logging

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -33,12 +33,6 @@ class BaseConfiguration(object):
 
     SYSTEM = 'koji'
 
-    # Available backends are: console, file, journal.
-    LOG_BACKEND = 'journal'
-
-    # Path to log file when LOG_BACKEND is set to "file".
-    LOG_FILE = 'freshmaker.log'
-
     # Available log levels are: debug, info, warn, error.
     LOG_LEVEL = 'info'
 
@@ -210,7 +204,6 @@ class BaseConfiguration(object):
 
 class DevConfiguration(BaseConfiguration):
     DEBUG = True
-    LOG_BACKEND = 'console'
     LOG_LEVEL = 'debug'
 
     MESSAGING_TOPIC_PREFIX = ['org.fedoraproject.dev', 'org.fedoraproject.stg']
@@ -236,7 +229,6 @@ class DevConfiguration(BaseConfiguration):
 
 
 class TestConfiguration(BaseConfiguration):
-    LOG_BACKEND = 'console'
     LOG_LEVEL = 'debug'
     DEBUG = True
 

--- a/freshmaker/__init__.py
+++ b/freshmaker/__init__.py
@@ -49,7 +49,7 @@ conf = init_config(app)
 db = SQLAlchemy(app)  # type: Any
 
 init_logging(conf)
-setup_logger()
+setup_logger(conf)
 log = getLogger(__name__)
 
 login_manager = LoginManager()

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -139,14 +139,6 @@ class Config(object):
             'type': bool,
             'default': False,
             'desc': 'Debug mode'},
-        'log_backend': {
-            'type': str,
-            'default': None,
-            'desc': 'Log backend'},
-        'log_file': {
-            'type': str,
-            'default': '',
-            'desc': 'Path to log file'},
         'log_level': {
             'type': str,
             'default': 0,
@@ -506,19 +498,6 @@ class Config(object):
     #
     # Register your _setifok_* handlers here
     #
-
-    def _setifok_log_backend(self, s):
-        if s is None:
-            self._log_backend = "console"
-        elif s not in logger.supported_log_backends():
-            raise ValueError("Unsupported log backend")
-        self._log_backend = str(s)
-
-    def _setifok_log_file(self, s):
-        if s is None:
-            self._log_file = ""
-        else:
-            self._log_file = str(s)
 
     def _setifok_log_level(self, s):
         level = str(s).lower()


### PR DESCRIPTION
# Improve logging

There are a few issues with the current logging, let's enhance it!

### Issue: lack of debug-level logs
The cause was that in the `logger.py` module, the log level was being set from an environment variable called "DEBUG" that was not being set in the deployment.

Since there is a setting for the config level in the configuration file, I changed it to get the setting from there.

After doing that, I made a quick deployment to dev and I saw some debug-level lines in the logs.

### Issue: too many info-level logs from ~~pyxis~~ gql, including its data
The solution I found was to include change the gql module logging level in the configs. That change is in the internal repo.

### Issue: duplicated log lines in console
The cause behind this issue was that there were two handlers to the console: one in the root logger, which was being configured with a stream handler to `stderr` by the `basicConfig()` commands, and the second in the child "freshmaker" logger, pointing to `stdout`.

The solution was to  explicitly set the console handler in the root logger and not set it in the freshmaker logger. That way we have only one logger, and also  prevent calls from basicConfig and logging.debug/warning/... to create a standard handler in the root logger.

Also, I removed the 'journal' and 'file' logging backends, which were not really used in practice. We decided to remove
those options and the related code to simplify the project.


JIRA: CWFHEALTH-2103