### PR TITLE
Update event state when the last build failed due to ODCS compose error

### DIFF
--- a/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
+++ b/freshmaker/handlers/internal/update_db_on_odcs_compose_fail.py
@@ -69,3 +69,5 @@ class UpdateDBOnODCSComposeFail(BaseHandler):
                 "ODCS compose %r is in failed state." % compose_id)
 
         db.session.commit()
+        db_event = builds_with_compose[0].event
+        self._mark_event_complete_when_all_builds_done(db_event)


### PR DESCRIPTION
When the last build in event failed due to ODCS compose error, the build state will be changed to FAILED, but Freshmaker doesn't update the event to COMPLETE state.

JIRA: CWFHEALTH-2162