### PR TITLE
Automatic rebuild of old operators/operands images

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -362,6 +362,13 @@ class Config(object):
             'default': '',
             'desc': 'A suffix to add to the rebuilt_nvr release in addition to the timestamp.',
         },
+        'bundle_include_previous_rebuilds': {
+            'type': bool,
+            'default': True,
+            'desc': 'When True, enables an automatic search in bundle rebuilds for previous'
+                    'Freshmaker builds of the current operator/operand images, and replace them'
+                    'in the bundle.'
+        },
         'container_release_categories': {
             'type': tuple,
             'default': ("Generally Available", "Tech Preview", "Beta",),


### PR DESCRIPTION
Sometimes, it can happen that a bundle loses track of the latest image of an operator/operand, in case they are both rebuilt but the bundle rebuild fails to ship. In this case, new rebuilds of those operator/operand will no longer trigger a rebuild of the bundle.

For example, imagine we have a bundle 'bundle-2-234' and a related image 'foo-1-123', and the following happens:
1. the image gets rebuilt to 'foo-1-123.234' and the bundle also happens a rebuild triggered, but it fails to ship
2. then the image gets rebuild again to 'foo-123-456'
3. this new rebuild of 'foo-1-123' will not trigger a rebuild of the        bundle, as it is not related to 'foo-123-456'

The manual overriding feature can be used to circumvent this issue, but it is better if we can make an automatic solution.

This commit enables FM to automatically search, during bundle rebuilds, for previous rebuilds of those related images and replace them with the latest images.

JIRA: CWFHEALTH-2141