### PR TITLE
Fix doc build job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=packages::$(sed 's/#.*//' yum-packages-devel.txt)
 
       - name: Build docs
-        uses: fedora-python/tox-github-action@master
+        uses: fedora-python/tox-github-action
         with:
           dnf_install: ${{ steps.packages.outputs.packages }}
           tox_env: docs


### PR DESCRIPTION
The "tox-github-action" has been changed to use `main` branch as default branch and `master` branch is not available now.