### PR TITLE
Fix errors pointed by new flake8 version

### DIFF
--- a/freshmaker/handlers/__init__.py
+++ b/freshmaker/handlers/__init__.py
@@ -238,11 +238,11 @@ class BaseHandler(object):
         must set the context, so in case of a failure, the event or artifact
         build can be marked as FAILED by a consumer class.
         """
-        if type(db_object) == Event:
+        if isinstance(db_object, Event):
             self._db_event_id = db_object.id
             self._db_artifact_build_id = None
             self._log_prefix = "%s: " % str(db_object)
-        elif type(db_object) == ArtifactBuild:
+        elif isinstance(db_object, ArtifactBuild):
             self._db_event_id = db_object.event.id
             self._db_artifact_build_id = db_object.id
             # Prefix logs with "<models.Event> (<models.ArtifactBuild>):".

--- a/freshmaker/types.py
+++ b/freshmaker/types.py
@@ -48,7 +48,7 @@ class ArtifactBuildState(Enum):
             None
         ]
 
-        if type(value) == int:
+        if isinstance(value, int):
             self.counter = counters[value]
         else:
             self.counter = None
@@ -74,7 +74,7 @@ class EventState(Enum):
             freshmaker_event_canceled_counter
         ]
 
-        if type(value) == int:
+        if isinstance(value, int):
             self.counter = counters[value]
         else:
             self.counter = None

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -2331,7 +2331,7 @@ class TestDeduplicateImagesToRebuild(helpers.FreshmakerTestCase):
     def _create_imgs(self, nvrs):
         images = []
         for data in nvrs:
-            if type(data) == list:
+            if isinstance(data, list):
                 nvr = data[0]
                 image = self._create_img(nvr)
                 image.update(data[1])


### PR DESCRIPTION
A new version of flake8 was released, and it complains about type comparison in some places in our code:
> E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`"

This commit fixes these comparisons according to flake8 suggestion.

For completeness, here are the errors that popped up prior to this fix:
``` python
./freshmaker/handlers/__init__.py:241:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./freshmaker/handlers/__init__.py:245:14: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./freshmaker/types.py:51:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./freshmaker/types.py:77:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./tests/test_image.py:2334:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```