### PR TITLE
Retry Pyxis requests on timeout

### DIFF
--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -2,6 +2,7 @@ git
 httpd
 mod_auth_gssapi
 mod_ssl
+python3-backoff
 python3-defusedxml
 python3-dogpile-cache
 python3-fedmsg


### PR DESCRIPTION
The gql RequestsHTTPTransport has retries enabled, but it doesn't retry when Pyxis requests timeout, for some requests, Pyxis may take more time than its gateway timeout value to process them, and it will return the result with error in response. In such cases, retrying may work.

This is a workaround for JIRA: CLOUDWF-9342