### PR TITLE
Remove unused pulp-docker configs and function

### DIFF
--- a/freshmaker/pulp.py
+++ b/freshmaker/pulp.py
@@ -79,21 +79,3 @@ class Pulp(object):
         }
         repos = self._rest_post("repositories/search/", json.dumps(query_data))
         return [repo["notes"]["content_set"] for repo in repos if "content_set" in repo["notes"]]
-
-    @retry(wait_on=requests.exceptions.RequestException)
-    def get_docker_repository_name(self, cdn_repo):
-        """
-        Getting docker repository name from pulp using cdn repo name.
-
-        :param str cdn_repo: The CDN repo name from Errata Tool.
-        :rtype: str
-        :return: Docker repository name.
-        """
-        response = self._rest_get("repositories/%s/" % cdn_repo, distributors=True)
-
-        docker_repository_name = None
-        for distributor in response["distributors"]:
-            if distributor["distributor_type_id"] == "docker_distributor_web":
-                docker_repository_name = distributor["config"]["repo-registry-id"]
-                break
-        return docker_repository_name

--- a/tests/test_pulp.py
+++ b/tests/test_pulp.py
@@ -162,29 +162,6 @@ class TestPulp(helpers.FreshmakerTestCase):
         self.assertEqual(['rhel-7-workstation-rpms', 'rhel-7-desktop-rpms'],
                          content_sets)
 
-    @patch('freshmaker.pulp.requests.get')
-    def test_get_docker_repository_name(self, get):
-        get.return_value.json.return_value = {
-            'display_name': 'foo-526',
-            'description': 'Foo',
-            'distributors': [
-                {'repo_id': 'foo-526',
-                 'distributor_type_id': 'docker_distributor_web',
-                 'config': {'repo-registry-id': 'scl/foo-526'}}
-            ]
-        }
-
-        pulp = Pulp(self.server_url, cert=self.cert)
-        repo_name = pulp.get_docker_repository_name("foo-526")
-
-        get.assert_called_once_with(
-            '{}pulp/api/v2/repositories/foo-526/'.format(self.server_url),
-            params={"distributors": True},
-            cert=self.cert,
-            timeout=conf.requests_timeout)
-
-        self.assertEqual(repo_name, "scl/foo-526")
-
     @patch('freshmaker.pulp.requests.post')
     @patch('freshmaker.pulp.requests.get')
     def test_retrying_calls(self, get, post):
@@ -192,10 +169,6 @@ class TestPulp(helpers.FreshmakerTestCase):
         post.side_effect = exceptions.HTTPError("Connection error: post")
 
         pulp = Pulp(self.server_url, cert=self.cert)
-
-        with self.assertRaises(exceptions.HTTPError):
-            pulp.get_docker_repository_name("test")
-        self.assertGreater(get.call_count, 1)
 
         with self.assertRaises(exceptions.HTTPError):
             pulp.get_content_set_by_repo_ids(['test1', 'test2'])


### PR DESCRIPTION
A while ago, Pulp authentication was refactored, and the pulp-docker configurations became unused
(https://github.com/redhat-exd-rebuilds/freshmaker/commit/1c87c5220c718cc221cdae2396bf5cb57a06beef).

This commit removes an unused function in the pulp module, and the related tests.

JIRA: CWFHEALTH-2084