### PR TITLE
Send Pyxis request with less repositories

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -997,7 +997,7 @@ class PyxisAPI(object):
             images = []
             # Split the repos to small chunks to generate "small" queries
             repos_iterator = iter(repos)
-            chunk_size = 100
+            chunk_size = 50
             for i in range(0, len(repos), chunk_size):
                 repos_chunk = {k: repos[k] for k in islice(repos_iterator, chunk_size)}
                 images_chunk = self.find_images_with_included_rpms(


### PR DESCRIPTION
Freshmaker has a Pyxis request which is used to find images that have particular content sets enabled and have particular rpms installed, this request is time consuming and it's hard to tell how complex this request will be because the query and filter is performed at Pyxis backend, and with the number of images grow in underlying database, same request can take more time to finish.

We're seeing request timeout with 100 repositories in a single request, adjust the number to 50 to workaround the issue.