### PR TITLE
Fix async build

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -855,6 +855,16 @@ class PyxisAPI(object):
         images = self.pyxis.find_images_by_names(names)
         return self._dicts_to_images(images)
 
+    def find_images_by_nvr(self, nvr):
+        """
+        Query Pyxis to get images of NVR
+
+        :param str nvr: image NVR
+        :rtype: list of dict
+        :return: list of images returned by Pyxis
+        """
+        return self.pyxis.find_images_by_nvr(nvr)
+
     def find_parent_brew_build_nvr_from_child(self, child_image, pyxis_api_instance=None):
         """
         Returns the parent brew build NVR of the input image. If the parent is not found it returns None.

--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -120,6 +120,7 @@ class PyxisGQL:
             ds.ContainerImage.architecture,
             ds.ContainerImage.brew.select(
                 ds.Brew.build,
+                ds.Brew.package,
             ),
             ds.ContainerImage.content_sets,
             ds.ContainerImage.parent_brew_build,

--- a/freshmaker/pyxis_gql_async.py
+++ b/freshmaker/pyxis_gql_async.py
@@ -133,6 +133,7 @@ class PyxisAsyncGQL:
             ds.ContainerImage.architecture,
             ds.ContainerImage.brew.select(
                 ds.Brew.build,
+                ds.Brew.package,
             ),
             ds.ContainerImage.content_sets,
             ds.ContainerImage.parent_brew_build,


### PR DESCRIPTION
1. Include `brew.package` in image metadata returned by Pyxis, it's used by async build feature.

2. In async build handler, PyxisAPI instance is used with its APIs, but while resolving an image, the resolve methods accepts a PyxisGQL instance, so async build fails with `find_images_by_nvr` method not found, just wrap the API in PyxisAPI as a workaround.