### PR TITLE
Fix pyxis timeout retry

### DIFF
--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -98,7 +98,10 @@ class PyxisGQL:
         if error is not None:
             trace_id = self._client.transport.response_headers.get("trace_id", False)
 
-            if "Pyxis API was unable to fetch data from MongoDB in time" in error:
+            if (
+                error["detail"]
+                and "Pyxis API was unable to fetch data from MongoDB in time" in error["detail"]
+            ):
                 raise PyxisGQLRequestTimeout(error=error, trace_id=trace_id)
             raise PyxisGQLRequestError(error=error, trace_id=trace_id)
 

--- a/tests/test_pyxis_gql.py
+++ b/tests/test_pyxis_gql.py
@@ -552,7 +552,7 @@ def test_log_trace_id(mock_client, mock_transport):
     result = {
         "find_images": {
             "data": [],
-            "error": ["something went wrong"],
+            "error": {"status": 500, "detail": "something went wrong"},
             "page": 0,
             "page_size": 250,
             "total": 2,
@@ -574,6 +574,5 @@ def test_log_trace_id(mock_client, mock_transport):
             content_sets=["rhel-8-for-x86_64-baseos-rpms"],
         )
     except PyxisGQLRequestError as e:
-        print(e)
         assert e.error == str(result["find_images"]["error"])
         assert e.trace_id == mock_transport.return_value.response_headers["trace_id"]

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ ignore_outcome = True
 
 [flake8]
 skip_install = true
-ignore = E501,E731,W504
+ignore = E501,E731,W503,W504
 exclude = dev_scripts/*,freshmaker/migrations/*,.tox/*,build/*,__pycache__,scripts/print_handlers_md.py,.copr/*,.env
 
 [testenv:docs]


### PR DESCRIPTION
1. Fix retry for Pyxis request timeout
    
In 31cc4ca, we added retry mechanism when Pyxis request timeout, however
we detect the Pyxis request timeout by:

    if "Pyxis API was unable to fetch data from MongoDB in time" in error

`error` is actually a dict, not a string, so this doesn't work.

2. Disable flake8 W503

W503 warning in Flake8 goes against PEP 8 recommendation, disable it to
make it compatible with black.

    W503 line break before binary operator

https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator