### PR TITLE
Remove caching for some find images APIs

### DIFF
--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -438,7 +438,6 @@ class PyxisGQL:
 
         return images
 
-    @region.cache_on_arguments()
     def find_images_by_installed_rpms(
         self, rpm_names, content_sets=None, repositories=None, published=None, tags=None
     ):
@@ -518,7 +517,6 @@ class PyxisGQL:
 
         return images
 
-    @region.cache_on_arguments()
     def find_images_by_names(self, names):
         """Find all the images for a specific list of names.
 
@@ -569,7 +567,6 @@ class PyxisGQL:
 
         return images
 
-    @region.cache_on_arguments()
     def find_images_by_repository(
         self, repository: str, auto_rebuild_tags: Optional[list[str]] = None
     ) -> list:
@@ -628,7 +625,6 @@ class PyxisGQL:
 
         return images
 
-    @region.cache_on_arguments()
     def find_images_by_name_version(
         self, name, version, published=None, content_sets=None, limit=20
     ):


### PR DESCRIPTION
Caching should not be enabled for some find images APIs, because the result can change at any time, if we have caching for such APIs, images just be released may not be returned by these APIs which can cause wrong result of images to be rebuilt.

These APIs are from `pyxis_gql` module:

    1. find_images_by_installed_rpms
    2. find_images_by_names
    3. find_images_by_name_version
    4. find_images_by_repository

Caching for other find images APIs is fine:

    1. find_images_by_nvr
    2. find_images_by_nvrs