### PR TITLE
Exclude `total` field from Pyxis request's projection

### DIFF
--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -492,7 +492,6 @@ class PyxisGQL:
                 ),
                 ds.ContainerImagePaginatedResponse.page,
                 ds.ContainerImagePaginatedResponse.page_size,
-                ds.ContainerImagePaginatedResponse.total,
                 ds.ContainerImagePaginatedResponse.data.select(*self._get_image_projection()),
             )
 
@@ -510,8 +509,8 @@ class PyxisGQL:
                 ]
             images.extend(data)
 
-            # If page_size >= total, means all results have been fetched in the first page
-            if result["find_images"]["page_size"] >= result["find_images"]["total"]:
+            # This page has less items than the page size, it's the last page
+            if len(data) < result["find_images"]["page_size"]:
                 break
             page_num += 1
 

--- a/freshmaker/pyxis_gql_async.py
+++ b/freshmaker/pyxis_gql_async.py
@@ -513,7 +513,6 @@ class PyxisAsyncGQL:
                 ),
                 ds.ContainerImagePaginatedResponse.page,
                 ds.ContainerImagePaginatedResponse.page_size,
-                ds.ContainerImagePaginatedResponse.total,
                 ds.ContainerImagePaginatedResponse.data.select(*self._get_image_projection()),
             )
 
@@ -531,8 +530,8 @@ class PyxisAsyncGQL:
                 ]
             images.extend(data)
 
-            # If page_size >= total, means all results have been fetched in the first page
-            if result["find_images"]["page_size"] >= result["find_images"]["total"]:  # type: ignore[index]
+            # This page has less items than the page size, it's the last page
+            if len(data) < result["find_images"]["page_size"]:  # type: ignore[index]
                 break
             page_num += 1
 


### PR DESCRIPTION
The requests in find_images_by_installed_rpms API are very inefficient, including the `total` field can make the query performance much worse.