### PR TITLE
Append advisory name to message id

### DIFF
--- a/freshmaker/parsers/errata/state_change.py
+++ b/freshmaker/parsers/errata/state_change.py
@@ -59,6 +59,9 @@ class ErrataAdvisoryStateChangedParser(BaseParser):
         # advisory has been changed to a different state other than the one
         # in message, so we override advisory state with the state in message
         advisory.state = new_state
+        # Append advisory name to message id, this makes it easier to check which
+        # type of advisory triggered the event without opening Errata tool.
+        msg_id = f"{msg_id}.{str(advisory.name)}"
 
         # If advisory created by BOTAS and it's shipped,
         # then return BotasErrataShippedEvent event

--- a/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
+++ b/tests/handlers/koji/test_rebuild_flatpak_application_on_module_ready.py
@@ -228,7 +228,7 @@ class TestFlatpakModuleAdvisoryReadyEvent(helpers.ModelsTestCase):
         }
         event = self.consumer.get_abstracted_msg(msg)
         self.assertIsInstance(event, FlatpakModuleAdvisoryReadyEvent)
-        self.assertEqual("fake-msg-id", event.msg_id)
+        self.assertEqual("fake-msg-id.RHSA-123", event.msg_id)
         self.assertEqual(self.handler.can_handle(event), True)
 
     def test_event_state_updated_when_no_auto_rebuild_images(self):


### PR DESCRIPTION
Before b76bd0a, freshmaker appends the advisory name to message id when event is triggered by rpm advisory shipped message, it's still useful for us to know whether an event was triggered by E2E testing advisories (which type is RHBA) without opening Errata tool, so adding it back.