### PR TITLE
Update large rev hash in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,4 +4,4 @@
 # https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
 
 # Run code through black for formatting
-e3061441e1492f44386d10b1c6426162e6d0c81c
+9f8a38888502b4d7ab98f0654b9da38fdd888d04


### PR DESCRIPTION
Github changed the commit hash of the large reformatting rev after merging 🥲 

I'm making this quick patch to fix that.