### PR TITLE
Refactor the Container class

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -2,7 +2,7 @@
 
 import os
 import tempfile
-from typing import Optional, Tuple, Union  # noqa
+from typing import Any, Optional, Tuple, Union  # noqa
 
 from freshmaker.config import all_, any_  # noqa
 
@@ -257,7 +257,7 @@ class TestConfiguration(BaseConfiguration):
     AUTH_LDAP_USER_BASE = "ou=users,dc=example,dc=com"
     MAX_THREAD_WORKERS = 1
 
-    HANDLER_BUILD_ALLOWLIST = {}
+    HANDLER_BUILD_ALLOWLIST: dict[str, Any] = {}
 
     KRB_AUTH_CCACHE_FILE = "freshmaker_cc_$pid_$tid"
     ERRATA_TOOL_SERVER_URL = "http://localhost/"  # fake URL just for tests.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -67,7 +67,10 @@ def test_find_auto_rebuild_containers_with_older_rpms():
                 "data": [
                     {
                         "architecture": "amd64",
-                        "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                        "brew": {
+                            "build": "foobar-container-v0.13.0-12.1582340001",
+                            "package": "foobar-container",
+                        },
                         "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                         "edges": {
                             "rpm_manifest": {
@@ -96,7 +99,10 @@ def test_find_auto_rebuild_containers_with_older_rpms():
                     },
                     {
                         "architecture": "arm64",
-                        "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                        "brew": {
+                            "build": "foobar-container-v0.13.0-12.1582340001",
+                            "package": "foobar-container",
+                        },
                         "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                         "edges": {
                             "rpm_manifest": {
@@ -125,7 +131,10 @@ def test_find_auto_rebuild_containers_with_older_rpms():
                     },
                     {
                         "architecture": "arm64",
-                        "brew": {"build": "foobar-container-v0.12.2-5"},
+                        "brew": {
+                            "build": "foobar-container-v0.12.2-5",
+                            "package": "foobar-container",
+                        },
                         "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                         "edges": {
                             "rpm_manifest": {
@@ -154,7 +163,10 @@ def test_find_auto_rebuild_containers_with_older_rpms():
                     },
                     {
                         "architecture": "amd64",
-                        "brew": {"build": "foobar-container-v0.12.2-5"},
+                        "brew": {
+                            "build": "foobar-container-v0.12.2-5",
+                            "package": "foobar-container",
+                        },
                         "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                         "edges": {
                             "rpm_manifest": {
@@ -220,7 +232,10 @@ def test_resolve_image_build_metadata():
             "data": [
                 {
                     "architecture": "amd64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -249,7 +264,10 @@ def test_resolve_image_build_metadata():
                 },
                 {
                     "architecture": "arm64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -352,9 +370,7 @@ def test_resolve_image_build_metadata():
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
-    container = Container.load(images[0])
-    for img in images[1:]:
-        container.add_arch(img)
+    container = Container.create_from_images(images)
 
     koji_session = KojiService()
     container.resolve_build_metadata(koji_session)
@@ -384,7 +400,10 @@ def test_resolve_image_compose_sources():
             "data": [
                 {
                     "architecture": "amd64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -413,7 +432,10 @@ def test_resolve_image_compose_sources():
                 },
                 {
                     "architecture": "arm64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -534,9 +556,7 @@ def test_resolve_image_compose_sources():
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
-    container = Container.load(images[0])
-    for img in images[1:]:
-        container.add_arch(img)
+    container = Container.create_from_images(images)
 
     koji_session = KojiService()
     container.resolve_build_metadata(koji_session)
@@ -564,7 +584,10 @@ def test_resolve_content_sets():
             "data": [
                 {
                     "architecture": "amd64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -593,7 +616,10 @@ def test_resolve_content_sets():
                 },
                 {
                     "architecture": "arm64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -714,9 +740,7 @@ def test_resolve_content_sets():
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
-    container = Container.load(images[0])
-    for img in images[1:]:
-        container.add_arch(img)
+    container = Container.create_from_images(images)
 
     koji_session = KojiService()
     container.resolve_build_metadata(koji_session)
@@ -745,7 +769,10 @@ def test_resolve_published():
             "data": [
                 {
                     "architecture": "amd64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-x86_64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -774,7 +801,10 @@ def test_resolve_published():
                 },
                 {
                     "architecture": "arm64",
-                    "brew": {"build": "foobar-container-v0.13.0-12.1582340001"},
+                    "brew": {
+                        "build": "foobar-container-v0.13.0-12.1582340001",
+                        "package": "foobar-container",
+                    },
                     "content_sets": ["rhel-8-for-aarch64-baseos-rpms"],
                     "edges": {
                         "rpm_manifest": {
@@ -895,12 +925,9 @@ def test_resolve_published():
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     images = pyxis_gql.find_images_by_nvr("foobar-container-v0.13.0-12.1582340001")
-    container = Container.load(images[0])
-    for img in images[1:]:
-        container.add_arch(img)
+    container = Container.create_from_images(images)
 
     koji_session = KojiService()
     container.resolve_build_metadata(koji_session)
     container.resolve_compose_sources()
-    container.resolve_published(pyxis_gql)
     assert container.published is True


### PR DESCRIPTION
Changes to the Container class:

1. Change Container class to normal class

The class originally implemented using dataclass didn't have many of the advantages of dataclass, but rather made creating instances more difficult to understand. The reason is a container can have multi-arch images, most attributions doesn't have one-to-one mapping with a single image data.

2. Use class method `create_from_images` to create Container instances

It was implemented with instantiating it first then load per-arch data with `load` which is confusing.

3. Remove `resolve_published`

Just check if a container is published by checking that in all deliver repositories.

JIRA: CWFHEALTH-2313