### PR TITLE
Fix security issues pointed by Quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37-x86_64
+FROM registry.fedoraproject.org/fedora:38-x86_64
 
 LABEL \
     name="Freshmaker application" \

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -16,7 +16,6 @@ python3-kerberos
 python3-kobo
 python3-kobo-rpmlib
 python3-koji
-python3-krbcontext
 python3-ldap
 python3-libmodulemd
 python3-mock


### PR DESCRIPTION
Quay is pointing security issues in Freshmaker due to outdated packages. We currently install the latest package versions available for the fedora version in use. Therefore, to fix the issues, we needed to upgrade the fedora version.

Freshmaker was using fedora 37, and after upgrading to fedora 38, a number of issues were resolved. The rest of the issues that are marked as fixable are due to fedora 39 packages, but it won't become GA before a few weeks from now.

With f38, the total number of issues decreased from 21 to 13, and the number of fixable issues fell from 18 to 10. The issues with the packages `werkzeug`, `mako` and `mod-wsgi` were resolved.

### Possible concerns

The package `python3-krbcontext` is only available for f37. I removed it from `yum-packages.txt` and it didn't seem to impact freshmaker.

### Testing remarks

I made a deployment to the dev environment using the initial messages. There were no errors with them nor with any other message after 19h.


JIRA: CWFHEALTH-2317