### PR TITLE
only generate ErrataRPMAdvisoryShippedEvent for 'shipped live' events

### DIFF
--- a/freshmaker/parsers/errata/state_change.py
+++ b/freshmaker/parsers/errata/state_change.py
@@ -63,12 +63,14 @@ class ErrataAdvisoryStateChangedParser(BaseParser):
         # type of advisory triggered the event without opening Errata tool.
         msg_id = f"{msg_id}.{str(advisory.name)}"
 
-        # If advisory created by BOTAS and it's shipped,
-        # then return BotasErrataShippedEvent event
-        if advisory.state == "SHIPPED_LIVE" and advisory.reporter.startswith("botas"):
-            return BotasErrataShippedEvent(msg_id, advisory)
+        if advisory.state == "SHIPPED_LIVE":
+            # If advisory created by BOTAS and it's shipped,
+            # then return BotasErrataShippedEvent event
+            if advisory.reporter.startswith("botas"):
+                return BotasErrataShippedEvent(msg_id, advisory)
+            # If advisory is shipped, but not created by BOTAS,
+            # return ErrataRPMAdvisoryShippedEvent event
+            return ErrataRPMAdvisoryShippedEvent(msg_id, advisory)
 
         if advisory.is_flatpak_module_advisory_ready():
             return FlatpakModuleAdvisoryReadyEvent(msg_id, advisory)
-
-        return ErrataRPMAdvisoryShippedEvent(msg_id, advisory)


### PR DESCRIPTION
Check event state before issuing ErrataRPMAdvisoryShippedEvent

In a previous refactoring, we simplified how Freshmaker generates ErrataRPMAdvisoryShippedEvent's.
However, we forgot to check the state of the incoming errata events, and FM is currently issuing
ErrataRPMAdvisoryShippedEvent for all Errata events, even those which are not shipping events.

This commits places a check to ensure that ErrataRPMAdvisoryShippedEvent will only be issued
for the correct kind of Errata events.

### Testing remarks

I made a deployment to the dev environment, using the initial messages. I didn't see any errors for the initial messages nor the other messages after two days.

JIRA: CWFHEALTH-2351