### PR TITLE
Black-reformat step in tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ python -m pip install pip-tools
 more info available at: https://github.com/jazzband/pip-tools/
 
 
+# Formatting code with black
+
+Freshmaker currently uses `black` as formatter and style-checker. The CI workflow runs a black step
+to check for files that would be reformatted, and if it finds any such file, it will fail.
+
+You can manually run the `black-format` step in tox while developing to make sure that your code
+follows the repo standard. You can run
+```
+tox -e black-format <file1> <file2> ...
+```
+to point the reformat step to secific files that you would like, or
+```
+tox -e black-format
+```
+to run it in all the necessary files of the project.
+
+
 # Ignoring large reformattings with git blame
 
 The commits listed in `.git-blame-ignore-revs` are automatically ignored in github blame view

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,12 @@ deps = black
 commands = black --line-length 100 --check . \
     --extend-exclude="dev_scripts\/|freshmaker\/migrations\/|\.tox\/|build\/|__pycache__|scripts\/print_handlers_md\.py|\.copr\/|\.env"
 
+[testenv:black-format] 
+basepython = python3
+deps = black
+commands = black --line-length 100 {posargs:.} \
+    --extend-exclude="dev_scripts\/|freshmaker\/migrations\/|\.tox\/|build\/|__pycache__|scripts\/print_handlers_md\.py|\.copr\/|\.env"
+
 [testenv:mypy]
 description = type check
 deps =


### PR DESCRIPTION
Freshmaker is currently using a black-check step in tox. That means that black will check if it would reformat some file, and exits an error in case it would.

However, it would also be nice to have black actually reformat files during development, using the same parameters as will the check step.

This commit introduces the `black-reformat` in tox, which can be called manually during development to make the actual reformatting. It also introduces quick instructions on how to call it the readme file.

JIRA: CWFHEALTH-2357