### PR TITLE
Enable support for 'major incidents' in JIRA

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -82,8 +82,8 @@ class BaseConfiguration(object):
     # For more information see <https://github.com/redhat-exd-rebuilds/freshmaker>.
     #
     # Here is an example of allowing container images to be build as soon as
-    # an RHSA advisory with critical/important severity or with hightouch bug
-    # moves to SHIPPED_LIVE:
+    # an RHSA advisory with critical/important severity or related to a major
+    # incident moves to SHIPPED_LIVE:
     #
     # HANDLER_BUILD_ALLOWLIST = {
     #     "global": {
@@ -91,7 +91,7 @@ class BaseConfiguration(object):
     #             {'advisory_name': 'RHSA-.*'
     #              'advisory_state: 'SHIPPED_LIVE'},
     #             any_(
-    #                 {'has_hightouch_bugs': True},
+    #                 {'is_major_incident': True},
     #                 {'severity': ['critical', 'important']}
     #             )
     #         )
@@ -110,7 +110,7 @@ class BaseConfiguration(object):
     #             {'advisory_name': 'RHSA-.*'
     #              'advisory_state: 'SHIPPED_LIVE'},
     #             any_(
-    #                 {'has_hightouch_bugs': True},
+    #                 {'is_major_incident': True},
     #                 {'severity': ['critical', 'important']}
     #             )
     #         )

--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -297,7 +297,7 @@ class ErrataBaseEvent(BaseEvent):
             advisory_name=self.advisory.name,
             advisory_security_impact=self.advisory.security_impact,
             advisory_product_short_name=self.advisory.product_short_name,
-            advisory_has_hightouch_bug=self.advisory.has_hightouch_bug,
+            advisory_is_major_incident=self.advisory.is_major_incident,
             advisory_content_types=" ".join(self.advisory.content_types),
             **kwargs
         )

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -358,26 +358,26 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
         new={
             "RebuildImagesOnRPMAdvisoryChange": {
                 "image": {
-                    "advisory_has_hightouch_bug": True,
+                    "advisory_is_major_incident": True,
                 }
             }
         },
     )
     @patch.object(freshmaker.conf, "dry_run", new=True)
-    def test_allow_build_has_hightouch_bug(self):
+    def test_allow_build_is_major_incident(self):
         compose_4 = Compose(odcs_compose_id=4)
         db.session.add(compose_4)
         db.session.commit()
 
-        for has_hightouch_bug in [False, True]:
-            self.rhba_event.advisory.has_hightouch_bug = has_hightouch_bug
+        for is_major_incident in [False, True]:
+            self.rhba_event.advisory.is_major_incident = is_major_incident
             self.mock_find_images_to_rebuild.return_value = [[]]
             handler = RebuildImagesOnRPMAdvisoryChange()
             handler.handle(self.rhba_event)
 
             db_event = Event.get(db.session, message_id="123")
             self.assertEqual(db_event.state, EventState.SKIPPED.value)
-            if not has_hightouch_bug:
+            if not is_major_incident:
                 self.assertTrue(
                     db_event.state_reason.endswith(
                         "is not allowed by internal policy to trigger rebuilds."

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -521,7 +521,7 @@ class TestAllowBuildBasedOnAllowlist(helpers.FreshmakerTestCase):
             "MyHandler": {
                 "image": all_(
                     {"advisory_name": r"RHSA-\d+:\d+"},
-                    any_({"has_hightouch_bugs": True}, {"severity": ["critical", "important"]}),
+                    any_({"is_major_incident": True}, {"severity": ["critical", "important"]}),
                 )
             }
         },
@@ -531,7 +531,7 @@ class TestAllowBuildBasedOnAllowlist(helpers.FreshmakerTestCase):
         allowed = handler.allow_build(
             ArtifactType.IMAGE,
             advisory_name="RHSA-2017:1000",
-            has_hightouch_bugs=True,
+            is_major_incident=True,
             severity="low",
         )
         self.assertTrue(allowed)
@@ -539,7 +539,7 @@ class TestAllowBuildBasedOnAllowlist(helpers.FreshmakerTestCase):
         allowed = handler.allow_build(
             ArtifactType.IMAGE,
             advisory_name="RHSA-2017:1000",
-            has_hightouch_bugs=False,
+            is_major_incident=False,
             severity="critical",
         )
         self.assertTrue(allowed)
@@ -547,7 +547,7 @@ class TestAllowBuildBasedOnAllowlist(helpers.FreshmakerTestCase):
         allowed = handler.allow_build(
             ArtifactType.IMAGE,
             advisory_name="RHSA-2017:1000",
-            has_hightouch_bugs=False,
+            is_major_incident=False,
             severity="low",
         )
         self.assertFalse(allowed)
@@ -555,7 +555,7 @@ class TestAllowBuildBasedOnAllowlist(helpers.FreshmakerTestCase):
         allowed = handler.allow_build(
             ArtifactType.IMAGE,
             advisory_name="RHBA-2017:1000",
-            has_hightouch_bugs=False,
+            is_major_incident=False,
             severity="critical",
         )
         self.assertFalse(allowed)


### PR DESCRIPTION
Freshmaker currently supports major incidents only in Bugzilla, but some products file those trackers in JIRA.

This commit implements the logic to check if a tracker in JIRA corresponds to a major incident, by using the Errata API.

 The changes are the following:
- new function `Errata.has_jira_major_incidents` to check if a tracker in JIRA refers to a major incident
- new function `Errata._get_jira_issues` to fetch jira trackers
- inclusion of the new check in `ErrataAdvisory.from_advisory_id`, to add support to the JIRA trackers
- renaming of 'hightouch' to 'major_incident' in several points across the codebase, to reflect the new logic
- a new unit test for `Errata.has_jira_major_incidents`, with all the expected cases that it should handle
- adjustment to tests and configuration values, to conform to the new logic

JIRA: CWFHEALTH-2360