### PR TITLE
Replace the parent image only with the latest one

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -1578,7 +1578,7 @@ class PyxisAPI(object):
         """
         rpm_name_to_nvrs = {kobo.rpmlib.parse_nvr(nvr)["name"]: nvr for nvr in rpm_nvrs}
 
-        images = self.pyxis.find_images_by_name_version(
+        images = self.pyxis.find_latest_images_by_name_version(
             name, version, published=True, content_sets=content_sets
         )
         if not images:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3004,7 +3004,7 @@ def test_filter_out_already_fixed_published_images(mock_dig, mock_gfpi, mock_exi
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 @patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_nvr")
 @patch("freshmaker.image.ContainerImage.resolve")
 def test_get_fixed_published_image(
@@ -3106,7 +3106,7 @@ def test_get_fixed_published_image(
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 @patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_nvr")
 def test_get_fixed_published_image_not_found(
     find_images_by_nvr, published_images, mock_exists, gql_client
@@ -3128,7 +3128,7 @@ def test_get_fixed_published_image_not_found(
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 def test_get_fixed_published_image_diff_repo(published_images, mock_exists, gql_client):
     latest_rhel7_image_pyxis = {
         "brew": {"build": "rhel-server-container-7.9-189"},
@@ -3169,7 +3169,7 @@ def test_get_fixed_published_image_diff_repo(published_images, mock_exists, gql_
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 def test_get_fixed_published_image_missing_rpm(published_images, mock_exists, gql_client):
     latest_rhel7_image_pyxis = {
         "brew": {"build": "rhel-server-container-7.9-189"},
@@ -3210,7 +3210,7 @@ def test_get_fixed_published_image_missing_rpm(published_images, mock_exists, gq
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 def test_get_fixed_published_image_modularity_mismatch(published_images, mock_exists, gql_client):
     latest_rhel8_image_pyxis = {
         "brew": {"build": "rhel-server-container-8.2-189"},
@@ -3251,7 +3251,7 @@ def test_get_fixed_published_image_modularity_mismatch(published_images, mock_ex
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 def test_get_fixed_published_image_rpm_too_old(published_images, mock_exists, gql_client):
     latest_rhel7_image_pyxis = {
         "brew": {"build": "rhel-server-container-7.9-189"},
@@ -3292,7 +3292,7 @@ def test_get_fixed_published_image_rpm_too_old(published_images, mock_exists, gq
 @pytest.mark.usefixtures("pyxis_graphql_schema")
 @patch("freshmaker.pyxis_gql.Client")
 @patch("os.path.exists", return_value=True)
-@patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_name_version")
+@patch("freshmaker.pyxis_gql.PyxisGQL.find_latest_images_by_name_version")
 @patch("freshmaker.pyxis_gql.PyxisGQL.find_images_by_nvr")
 def test_get_fixed_published_image_not_found_by_nvr(
     find_images_by_nvr, published_images, mock_exists, gql_client

--- a/tests/test_pyxis_gql.py
+++ b/tests/test_pyxis_gql.py
@@ -472,7 +472,7 @@ def test_pyxis_graphql_find_images_by_names():
     assert images == result["find_images"]["data"]
 
 
-def test_pyxis_graphql_find_images_by_name_version():
+def test_pyxis_graphql_find_latest_images_by_name_version():
     pyxis_schema_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "fixtures",
@@ -528,7 +528,7 @@ def test_pyxis_graphql_find_images_by_name_version():
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
     flexmock(Client).should_receive("execute").and_return(copy.deepcopy(result))
 
-    images = pyxis_gql.find_images_by_name_version(
+    images = pyxis_gql.find_latest_images_by_name_version(
         "foobar-container",
         "v0.13.0",
         published=True,
@@ -567,7 +567,7 @@ def test_log_trace_id(mock_client, mock_transport):
     pyxis_gql = PyxisGQL(url="graphql.pyxis.local", cert="/path/to/cert")
 
     try:
-        pyxis_gql.find_images_by_name_version(
+        pyxis_gql.find_latest_images_by_name_version(
             "foobar-container",
             "v0.13.0",
             published=True,

--- a/tests/test_pyxis_gql_async.py
+++ b/tests/test_pyxis_gql_async.py
@@ -58,11 +58,7 @@ class TestPyxisAsyncGQL(TestCase):
 
     def test_query(self, mock_gql_client):
         ds = self.pyxis_gql_async.dsl_schema
-        fake_query = ds.Query.find_repositories(
-            page=0,
-            page_size=2,
-            filter={},
-        ).select(
+        fake_query = ds.Query.find_repositories(page=0, page_size=2, filter={}).select(
             ds.ContainerRepositoryPaginatedResponse.error.select(
                 ds.ResponseError.status,
                 ds.ResponseError.detail,
@@ -512,7 +508,7 @@ class TestPyxisAsyncGQL(TestCase):
         mock_gql_client.return_value.__aenter__.return_value.execute.assert_awaited()
         assert images == result["find_images"]["data"]
 
-    def test_find_images_by_name_version(self, mock_gql_client):
+    def test_find_latest_images_by_name_version(self, mock_gql_client):
         result = {
             "find_images": {
                 "data": [{"foo": "bar"}],
@@ -525,7 +521,7 @@ class TestPyxisAsyncGQL(TestCase):
         mock_gql_client.return_value.__aenter__.return_value.execute.return_value = deepcopy(result)
 
         images = asyncio.run(
-            self.pyxis_gql_async.find_images_by_name_version(name="foo-repo", version="1.23")
+            self.pyxis_gql_async.find_latest_images_by_name_version(name="foo-repo", version="1.23")
         )
         mock_gql_client.return_value.__aenter__.return_value.execute.assert_awaited()
         assert images == result["find_images"]["data"]
@@ -548,7 +544,9 @@ class TestPyxisAsyncGQL(TestCase):
 
         with self.assertRaises(PyxisGQLRequestError) as cm:
             asyncio.run(
-                self.pyxis_gql_async.find_images_by_name_version(name="foo-repo", version="1.23")
+                self.pyxis_gql_async.find_latest_images_by_name_version(
+                    name="foo-repo", version="1.23"
+                )
             )
         exception = cm.exception
         self.assertEqual(exception.error, str(result["find_images"]["error"]))


### PR DESCRIPTION
Due to regressing content, it might happen, in rare conditions, that the parent image of the image we are rebuilding after a CVE fix doesn't include all the latest fixes.

Example: we have 3 images:
	NVR | CVE fixes
	foo-1-125: fix-a, fix-b
	foo-1-124: fix-a, fix-c
	bar-2-220: fix-a, fix-b
foo is parent of bar. Before this change, Freshmaker would ask Pyxis if there's already a parent image fixing fix-c, and it would return foo-1-124, so that Freshmaker can use that as parent of bar. But that image is missing fix-b!
To prevent this issue, from now on, Freshmaker ask to Pyxis only the latest image.

Tests are not updated, since the current tests should cover the case.