### PR TITLE
 Identify RHSAs with compliance priority bugs/issues

### DIFF
--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -298,6 +298,7 @@ class ErrataBaseEvent(BaseEvent):
             advisory_security_impact=self.advisory.security_impact,
             advisory_product_short_name=self.advisory.product_short_name,
             advisory_is_major_incident=self.advisory.is_major_incident,
+            advisory_is_compliance_priority=self.advisory.is_compliance_priority,
             advisory_content_types=" ".join(self.advisory.content_types),
             **kwargs
         )

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -539,6 +539,46 @@ class TestErrata(helpers.FreshmakerTestCase):
         has_major_incidents = self.errata.has_jira_major_incidents("123")
         self.assertFalse(has_major_incidents)
 
+    @patch.object(Errata, "_get_jira_issues")
+    def test_has_compliance_priority_jira_label(self, get_jira_issues):
+        get_jira_issues.return_value = [
+            {
+                "id_jira": 123456,
+                "key": "RHEL-3321",
+                "summary": "CVE-2023-1234 foopack: Heap buffer overflow in Foo Codec [rhel-1.2.3.z]",
+                "status": "Closed",
+                "is_private": True,
+                "labels": [
+                    "compliance-priority",
+                ],
+            }
+        ]
+        has_compliance_priority = self.errata.has_compliance_priority_jira_label("123")
+        self.assertTrue(has_compliance_priority)
+
+        get_jira_issues.return_value = [
+            {
+                "id_jira": 123456,
+                "key": "RHEL-3322",
+                "summary": "CVE-2023-1235 barpack: Heap buffer overflow in Bar Codec [rhel-1.2.3.z]",
+                "status": "Closed",
+                "is_private": True,
+                "labels": [
+                    "CVE-2023-1235",
+                ],
+            }
+        ]
+        has_compliance_priority = self.errata.has_compliance_priority_jira_label("123")
+        self.assertFalse(has_compliance_priority)
+
+        get_jira_issues.return_value = []
+        has_compliance_priority = self.errata.has_compliance_priority_jira_label("123")
+        self.assertFalse(has_compliance_priority)
+
+        get_jira_issues.return_value = {"error": "Bad errata id given: 123"}
+        has_compliance_priority = self.errata.has_compliance_priority_jira_label("123")
+        self.assertFalse(has_compliance_priority)
+
 
 class TestErrataAuthorizedGet(helpers.FreshmakerTestCase):
     def setUp(self):


### PR DESCRIPTION
Freshmaker has a preconfigured allowlist that currently only permits advisories of critical and important severity to trigger image rebuilds. There is a requirement to address moderate and low CVEs, though.

To address the new requirement, this allowlist needs to be expanded to include moderate and low security impact RHSAs. However, not all moderate/low CVE fix RHSA advisories should trigger Freshmaker rebuilds. Freshmaker should only react to moderate/low CVE fix advisories when they have any security compliance bugs/issues attached.

This commit implements the check for compliance priority issues and bugs.

The changes are the following:
- new parameter `is_compliance_priority` in the `ErrataAdvisory` class
- logic to fetch 'compliance-priority+' flag in bugs in  `ErrataAdvisory.from_advisory_id`
- new function to check for 'compliance-priority' flag in jira issues,  and an unit test
- inclusion of a new parameter to be checked, in `ErrataBaseEvent`,  inheriting its value from `ErrataAdvisory`
- (chore) a small adjustment to the log message in  `has_jira_major_incidents`, where the advisory id was being reported  twice

JIRA: CWFHEALTH-2490