### PR TITLE
Introduce config var COMPLIANCE_PRIORITY_REPOSITORIES_REMOTE_FILE

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -200,6 +200,8 @@ class BaseConfiguration(object):
     # repositories that should be searched for unpublished images, specifically because of EUS base images
     UNPUBLISHED_EXCEPTIONS: list[dict[str, str]] = []
 
+    COMPLIANCE_PRIORITY_REPOSITORIES_REMOTE_FILE = None
+
 
 class DevConfiguration(BaseConfiguration):
     DEBUG = True

--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -450,6 +450,11 @@ class Config(object):
             "default": "-hidden-rpms$",
             "desc": "Pattern for content sets which will be excluded while generating composes",
         },
+        "compliance_priority_repositories_remote_file": {
+            "type": str,
+            "default": "",
+            "desc": "URL to a remote file containing image repositories enabled for rebuilding due to compliance priority CVEs",
+        },
     }
 
     def __init__(self, conf_section_obj):


### PR DESCRIPTION
To facilitate configurable predefined image repositories for moderate/low RHSA rebuilds, Freshmaker will have the capability to retrieve predefined image repositories from a remote URL. For this purpose we are introducing the configuration vaiable COMPLIANCE_PRIORITY_REPOSITORIES_REMOTE_FILE.

ref: CWFHEALTH-2491