### PR TITLE
Enable use of external repos in lower-severity rebuilds

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -513,6 +513,7 @@ class PyxisAPI(object):
         published=True,
         release_categories=conf.container_release_categories,
         auto_rebuild=True,
+        names: list[str] | None = None,
     ):
         """
         Returns dict with repository name as key and ContainerRepository as
@@ -524,12 +525,13 @@ class PyxisAPI(object):
             release categories (options: Deprecated, Generally Available, Beta,
             Tech Preview)
         :type release_categories: tuple[str] or list[str]
+        :param names: names of the repos to limit the search to (optional)
         :rtype: dict
         :return: Dict with repository name as key and ContainerRepository as
             value.
         """
         repositories = self.pyxis.find_repositories(
-            published=published, release_categories=release_categories
+            published=published, release_categories=release_categories, names=names
         )
 
         # If the query is for published images, add configurable repos for
@@ -1019,6 +1021,7 @@ class PyxisAPI(object):
         published=True,
         release_categories=conf.container_release_categories,
         leaf_container_images=None,
+        repositories: list[str] | None = None,
     ):
         """Query Pyxis and find containers which contain given
         package from one of content sets
@@ -1040,12 +1043,15 @@ class PyxisAPI(object):
         :param list leaf_container_images: List of NVRs of leaf images to
             consider for the rebuild. If not set, all images found in
             Pyxis will be considered for rebuild.
+        :param repositories: Repos to restrict the search to (Optional)
+        :type repositories: list of str
 
         :return: a list of dictionaries which represents container images
         :rtype: list
         """
 
-        repos = self.find_repositories(published, release_categories)
+        repos = self.find_repositories(published, release_categories, names=repositories)
+
         if not repos:
             return []
         if not leaf_container_images:
@@ -1335,6 +1341,7 @@ class PyxisAPI(object):
         filter_fnc=None,
         leaf_container_images=None,
         skip_nvrs=None,
+        repositories: list[str] | None = None,
     ):
         """
         Find images to rebuild through image build layers
@@ -1363,6 +1370,8 @@ class PyxisAPI(object):
             Pyxis will be considered for rebuild. Note that `published`
             is not respected when `leaf_container_images` are used.
         :param list skip_nvrs: List of NVRs of images to be skipped.
+        :param repositories: Repos to restrict the search to (Optional)
+        :type repositories: list of str
         """
         images = self.find_images_with_packages_from_content_set(
             rpm_nvrs,
@@ -1371,6 +1380,7 @@ class PyxisAPI(object):
             published,
             release_categories,
             leaf_container_images=leaf_container_images,
+            repositories=repositories,
         )
 
         # Remove any hotfix images from list of images

--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -166,16 +166,23 @@ class PyxisGQL:
         return projection
 
     @region.cache_on_arguments()
-    def find_repositories(self, published=None, release_categories=None, auto_rebuild_tags=None):
+    def find_repositories(
+        self,
+        published=None,
+        release_categories=None,
+        auto_rebuild_tags=None,
+        names: list[str] | None = None,
+    ):
         """Get image repositories
 
         :param bool published: published or unpublished repositories
         :param list release_categories: list of release categories
         :param list auto_rebuild_tags: list of tags enabled for auto rebuild
+        :param names: names of the repos to limit the search to (optional)
         :return: list of image repositories
         :rtype: list
         """
-        query_filter = {}
+        query_filter: dict = {}
         query_filter["and"] = []
         # Query Red Hat repositories only
         query_filter["and"].append({"vendor_label": {"eq": "redhat"}})
@@ -183,11 +190,13 @@ class PyxisGQL:
         if isinstance(published, bool):
             query_filter["and"].append({"published": {"eq": published}})
 
-        if release_categories is not None:
+        if release_categories:
             query_filter["and"].append({"release_categories": {"in": release_categories}})
 
-        if auto_rebuild_tags is not None:
+        if auto_rebuild_tags:
             query_filter["and"].append({"auto_rebuild_tags": {"in": auto_rebuild_tags}})
+        if names:
+            query_filter["and"].append({"repository": {"in": names}})
 
         repositories = []
         ds = self.dsl_schema

--- a/freshmaker/pyxis_gql_async.py
+++ b/freshmaker/pyxis_gql_async.py
@@ -176,15 +176,17 @@ class PyxisAsyncGQL:
 
     async def find_repositories(
         self,
-        published: Optional[bool] = None,
-        release_categories: Optional[list[str]] = None,
-        auto_rebuild_tags: Optional[list[str]] = None,
+        published: bool | None = None,
+        release_categories: list[str] | None = None,
+        auto_rebuild_tags: list[str] | None = None,
+        names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Get image repositories
 
         :param bool published: published or unpublished repositories
         :param list release_categories: list of release categories
         :param list auto_rebuild_tags: list of tags enabled for auto rebuild
+        :param names: names of the repos to limit the search to (optional)
         :return: list of image repositories
         :rtype: list
         """
@@ -196,11 +198,13 @@ class PyxisAsyncGQL:
         if isinstance(published, bool):
             query_filter["and"].append({"published": {"eq": published}})
 
-        if release_categories is not None:
+        if release_categories:
             query_filter["and"].append({"release_categories": {"in": release_categories}})
 
-        if auto_rebuild_tags is not None:
+        if auto_rebuild_tags:
             query_filter["and"].append({"auto_rebuild_tags": {"in": auto_rebuild_tags}})
+        if names:
+            query_filter["and"].append({"repository": {"in": names}})
 
         repositories = []
         ds = self.dsl_schema

--- a/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
+++ b/tests/handlers/koji/test_rebuild_images_on_rpm_advisory_change.py
@@ -20,7 +20,10 @@
 # SOFTWARE.
 
 import json
+from unittest import TestCase
 from unittest.mock import patch, PropertyMock, Mock, call
+
+from requests.exceptions import HTTPError
 
 import freshmaker
 
@@ -475,7 +478,7 @@ class TestRebuildImagesOnRPMAdvisoryChange(helpers.ModelsTestCase):
         self.assertEqual(EventState.BUILDING.value, db_event.state)
 
 
-class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
+class TestFindImagesToRebuild(helpers.ModelsTestCase):
     def setUp(self):
         super(TestFindImagesToRebuild, self).setUp()
 
@@ -535,6 +538,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=conf.container_release_categories,
             leaf_container_images=None,
             skip_nvrs=None,
+            repositories=None,
         )
 
     @patch.object(
@@ -556,6 +560,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=conf.container_release_categories,
             leaf_container_images=None,
             skip_nvrs=None,
+            repositories=None,
         )
 
     @patch.object(
@@ -591,6 +596,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=None,
             leaf_container_images=None,
             skip_nvrs=None,
+            repositories=None,
         )
 
     @patch.object(
@@ -615,6 +621,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=conf.container_release_categories,
             leaf_container_images=None,
             skip_nvrs=None,
+            repositories=None,
         )
 
     @patch.object(
@@ -640,6 +647,7 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=conf.container_release_categories,
             leaf_container_images=["foo", "bar"],
             skip_nvrs=None,
+            repositories=None,
         )
 
     @patch.object(
@@ -664,7 +672,55 @@ class TestFindImagesToRebuild(helpers.FreshmakerTestCase):
             release_categories=conf.container_release_categories,
             leaf_container_images=None,
             skip_nvrs=None,
+            repositories=None,
         )
+
+    @patch(
+        "freshmaker.handlers.koji.RebuildImagesOnRPMAdvisoryChange._lookup_external_repos",
+        return_value=["foo/bar/repo"],
+    )
+    def test_moderate_cve_external_repo(self, mock_lookup):
+        self.event.advisory.security_impact = "moderate"
+        self.event.advisory.is_compliance_priority = True
+
+        self.handler._find_images_to_rebuild(123456)
+
+        self.find_images_to_rebuild.assert_called_once_with(
+            ["httpd-2.4-11.el7"],
+            ["content-set-1", "pulp_repo_x86_64"],
+            filter_fnc=self.handler._filter_out_not_allowed_builds,
+            published=None,
+            release_categories=None,
+            leaf_container_images=None,
+            skip_nvrs=None,
+            repositories=["foo/bar/repo"],
+        )
+
+    @patch(
+        "freshmaker.handlers.koji.RebuildImagesOnRPMAdvisoryChange._lookup_external_repos",
+        side_effect=HTTPError("404 Client Error: not found for url: foo.bar/baz"),
+    )
+    def test_moderate_cve_external_repo_http_error(self, mock_lookup):
+        self.event.advisory.security_impact = "moderate"
+        self.event.advisory.is_compliance_priority = True
+
+        result = self.handler._find_images_to_rebuild(123456)
+
+        db_event = Event.get_or_create_from_event(db.session, self.event)
+        self.assertEqual(db_event.state, 3)
+        self.assertEqual(result, [])
+
+    @patch(
+        "freshmaker.handlers.koji.RebuildImagesOnRPMAdvisoryChange._lookup_external_repos",
+        return_value=[],
+    )
+    def test_moderate_cve_external_repo_empty(self, mock_lookup):
+        self.event.advisory.security_impact = "moderate"
+        self.event.advisory.is_compliance_priority = True
+
+        result = self.handler._find_images_to_rebuild(123456)
+
+        self.assertEqual(result, [])
 
 
 class TestAllowBuild(helpers.ModelsTestCase):
@@ -1813,3 +1869,21 @@ class TestRecordBatchesImages(helpers.ModelsTestCase):
         ).first()
         self.assertNotEqual(None, child_image)
         self.assertEqual(child_image.dep_on, None)
+
+
+class TestLookupExternalRepos(TestCase):
+    """Test RebuildImagesOnRPMAdvisoryChange._lookup_external_repos"""
+
+    @patch.object(
+        freshmaker.conf, "compliance_priority_repositories_remote_file", "foo.net/bar", create=True
+    )
+    @patch(
+        "freshmaker.handlers.koji.rebuild_images_on_rpm_advisory_change.load_remote_yaml",
+        return_value={"repositories": ["foo", "bar"]},
+    )
+    def test_retrieve_some_repos(self, mock_load):
+        handler = RebuildImagesOnRPMAdvisoryChange()
+
+        result = handler._lookup_external_repos()
+
+        self.assertEqual(result, ["foo", "bar"])


### PR DESCRIPTION
When rebuilding for lower-severity advisories, we do not want to check the images in  all repositories in Pyxis. Instead, we want to restrain our search to a (dynamic) short list of predefined repos, stored in a remote yaml file, as this is more efficient.

This commit implements this functionality through the following changes:
- new logic in `RebuildImagesOnRPMAdvisoryChange._find_images_to_rebuild` to fetch external repos from the remote yaml file, in case advisory priority is `moderate`
- new functions `RebuildImagesOnRPMAdvisoryChange._lookup_external_repos` and `utils.py/load_remote_yaml` to fetch the content of the remote yaml file
- new parameters `repositories` and `repositories` in the methods `PyxisAPI.find_images_with_packages_from_content_set`, `PyxisAPI.find_images_to_rebuild` and `PyxisAPI.find_repositories`, but mostly as a means of forwardng to `PyxisGQL/PyxisGQLAsync.find_repositories`
- new parameter `names` in  `PyxisGQL/PyxisGQLAsync.find_repositories` to limit the search to the received repo names
- (chore) removal of unnecessary `is not None` clauses in `PyxisGQL/PyxisGQLAsync`
- (chore) reorganization of imports in `utils.py` to conform with PEP8
- unit tests for the new functions and cases

JIRA: CWFHEALTH-2493