### PR TITLE
Request ODCS pulp composes with `use_only_compatible_arch` flag

### DIFF
--- a/freshmaker/odcsclient.py
+++ b/freshmaker/odcsclient.py
@@ -307,9 +307,13 @@ class FreshmakerODCSClient(object):
 
         odcs = create_odcs_client()
         if not self.handler.dry_run:
-            new_compose = odcs.new_compose(" ".join(content_sets), "pulp")
+            new_compose = odcs.new_compose(
+                " ".join(content_sets), "pulp", flags=["use_only_compatible_arch"]
+            )
         else:
-            new_compose = self._fake_odcs_new_compose(content_sets, "pulp")
+            new_compose = self._fake_odcs_new_compose(
+                content_sets, "pulp", flags=["use_only_compatible_arch"]
+            )
 
         return new_compose
 


### PR DESCRIPTION
With the `use_only_compatible_arch` flag, the ODCS produced repofile will use a $basearch variable in the repourl, then build task for an arch won't have irrelevant arch repos enabled. This can help especially for base image builds, when irrelevant arch repos are enabled, it can cause the build task to be slower and occupy more memory, and can cause unexpected issues like RHELBLD-14336 where base images can not be built due to x86_64 appstream repo is enabled for non-x86_64 build tasks.

JIRA:CWFHEALTH-2746