### PR TITLE
Fix unexpected argument 'flags' to _fake_odcs_new_compose

### DIFF
--- a/freshmaker/odcsclient.py
+++ b/freshmaker/odcsclient.py
@@ -311,9 +311,7 @@ class FreshmakerODCSClient(object):
                 " ".join(content_sets), "pulp", flags=["use_only_compatible_arch"]
             )
         else:
-            new_compose = self._fake_odcs_new_compose(
-                content_sets, "pulp", flags=["use_only_compatible_arch"]
-            )
+            new_compose = self._fake_odcs_new_compose(content_sets, "pulp")
 
         return new_compose
 


### PR DESCRIPTION
In `0a95329`, `flags` was also added to _fake_odcs_new_compose call, this function doesn't accept `flags` argument and we don't need to support it in the fake function.