### PR TITLE
Fix find_latest_images_by_name_version

### DIFF
--- a/freshmaker/pyxis_gql.py
+++ b/freshmaker/pyxis_gql.py
@@ -679,6 +679,9 @@ class PyxisGQL:
         )
 
         images = self.query(query_dsl)["find_images"]["data"]
+        if not images:
+            return []
+
         latest_nvr = images[0]["brew"]["build"]
 
         for img in images[1:]:


### PR DESCRIPTION
It doesn't handle the case when Pyxis returns empty images.