### PR TITLE
Fix for ET's builds-by-cve API new result format

### DIFF
--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -472,7 +472,7 @@ class Errata(object):
                                 # Remove '.arch.....' part from rpm's name
                                 # and make a list from them
                                 if arch != "SRPMS":
-                                    just_nvrs = [rpm.rsplit(".", 2)[0] for rpm in rpms]
+                                    just_nvrs = [rpm["filename"].rsplit(".", 2)[0] for rpm in rpms]
                                     nvrs.update(just_nvrs)
 
         return list(nvrs)

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -152,18 +152,68 @@ class MockedErrataAPI(object):
                                 "is_module": False,
                                 "variant_arch": {
                                     "PRODUCT1": {
-                                        "x86_64": ["libntirpc-1.4.3-4.el6rhs.x86_64.rpm"],
-                                        "ppc64le": ["libntirpc-1.4.3-4.el6rhs.ppc64le.rpm"],
-                                        "s390x": ["libntirpc-1.4.3-4.el6rhs.s390x.rpm"],
-                                        "aarch64": ["libntirpc-1.4.3-4.el6rhs.aarch64.rpm"],
-                                        "SRPMS": ["libntirpc-1.4.3-4.el6rhs.src.rpm"],
+                                        "x86_64": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.x86_64.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "ppc64le": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.ppc64le.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "s390x": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.s390x.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "aarch64": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.aarch64.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "SRPMS": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.src.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
                                     },
                                     "PRODUCT2": {
-                                        "x86_64": ["libntirpc-1.4.3-4.el6rhs.x86_64.rpm"],
-                                        "ppc64le": ["libntirpc-1.4.3-4.el6rhs.ppc64le.rpm"],
-                                        "s390x": ["libntirpc-1.4.3-4.el6rhs.s390x.rpm"],
-                                        "aarch64": ["libntirpc-1.4.3-4.el6rhs.aarch64.rpm"],
-                                        "SRPMS": ["libntirpc-1.4.3-4.el6rhs.src.rpm"],
+                                        "x86_64": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.x86_64.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "ppc64le": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.ppc64le.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "s390x": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.s390x.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "aarch64": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.aarch64.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
+                                        "SRPMS": [
+                                            {
+                                                "filename": "libntirpc-1.4.3-4.el6rhs.src.rpm",
+                                                "is_signed": True,
+                                            }
+                                        ],
                                     },
                                 },
                             }


### PR DESCRIPTION
Errata has changed its builds-by-cve API to return rpms in string list to list of dicts, old format example:

    "x86_64": [
        "krb5-libs-1.8.2-3.el6_0.7.i686.rpm",
        "krb5-libs-1.8.2-3.el6_0.7.x86_64.rpm"
    ]

new format:

    "x86_64": [
        {
            "filename": "krb5-libs-1.8.2-3.el6_0.7.i686.rpm",
            "is_signed": true
        },
        {
            "filename": "krb5-libs-1.8.2-3.el6_0.7.x86_64.rpm",
            "is_signed": true
        }
    ]

This commit updates Freshmaker to accommodate the changes in the result format introduced by the latest ET API.

JIRA: CLOUDWF-10046