### PR TITLE
Allow filtering out images by published repository name

### DIFF
--- a/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
+++ b/freshmaker/handlers/koji/rebuild_images_on_rpm_advisory_change.py
@@ -389,6 +389,7 @@ class RebuildImagesOnRPMAdvisoryChange(ContainerBuildHandler):
             image_name=parsed_nvr["name"],
             image_version=parsed_nvr["version"],
             image_release=parsed_nvr["release"],
+            image_published_repo=image.get("published_repo"),
         ):
             self.log_info("Skipping rebuild of image %s, not allowed by configuration", image.nvr)
             return True

--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -763,6 +763,11 @@ class PyxisAPI(object):
                 for auto_rebuild_tag in published_repo["auto_rebuild_tags"]:
                     if auto_rebuild_tag in tag_names:
                         image["release_categories"] = published_repo["release_categories"]
+                        # There can potentially be multiple published
+                        # repositories but we only store the first one we
+                        # encounter. This adds uncertainty, but it's good
+                        # enough for our current use case.
+                        image["published_repo"] = repository["repository"]
                         image_nvr_to_image[nvr] = image
                         break
                 else:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1178,6 +1178,9 @@ class TestQueryFromPyxis(helpers.FreshmakerTestCase):
         )
         self.assertEqual(len(ret), 2)
         self.assertEqual(["parent-1-2", "parent-1-3"], sorted([x.nvr for x in ret]))
+        self.assertEqual(
+            ["product/repo1", "product2/repo2"], sorted([x.get("published_repo") for x in ret])
+        )
 
     @patch("freshmaker.pyxis_gql.Client")
     @patch("os.path.exists")


### PR DESCRIPTION
Extend the image metadata available to allowlist/blocklist functionality, adding the published repository name on top of the existing NVR information.

The published repo name includes the registry namespace, which lets us fine-tune rebuild criteria for a group of images (products, releases, other subdivisions) without needing to maintain full lists of images in Freshmaker configuration.

JIRA: CWFHEALTH-3013