### PR TITLE
Add release name to ErrataAdvisory for filtering

### DIFF
--- a/freshmaker/errata.py
+++ b/freshmaker/errata.py
@@ -45,6 +45,7 @@ class ErrataAdvisory(object):
         content_types,
         security_impact=None,
         product_short_name=None,
+        release_name=None,
         cve_list=None,
         is_major_incident=None,
         is_compliance_priority=None,
@@ -58,6 +59,7 @@ class ErrataAdvisory(object):
         self.content_types = content_types
         self.security_impact = security_impact or ""
         self.product_short_name = product_short_name or ""
+        self.release_name = release_name or ""
         self.cve_list = cve_list or []
         self.is_major_incident = is_major_incident
         self.is_compliance_priority = is_compliance_priority
@@ -104,6 +106,7 @@ class ErrataAdvisory(object):
             return None
         erratum_data = erratum_data[0]
 
+        release_data = errata._get_release(errata_id)
         product_data = errata._get_product(erratum_data["product_id"])
         cve = data["content"]["content"]["cve"].strip()
         if cve:
@@ -139,6 +142,7 @@ class ErrataAdvisory(object):
             erratum_data["content_types"],
             security_impact,
             product_data["product"]["short_name"],
+            release_data["data"]["attributes"]["name"],
             cve_list,
             is_major_incident,
             is_compliance_priority,

--- a/freshmaker/events.py
+++ b/freshmaker/events.py
@@ -299,6 +299,7 @@ class ErrataBaseEvent(BaseEvent):
             advisory_name=self.advisory.name,
             advisory_security_impact=self.advisory.security_impact,
             advisory_product_short_name=self.advisory.product_short_name,
+            advisory_release_name=self.advisory.release_name,
             advisory_is_major_incident=self.advisory.is_major_incident,
             advisory_is_compliance_priority=self.advisory.is_compliance_priority,
             advisory_content_types=" ".join(self.advisory.content_types),

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -86,6 +86,10 @@ class MockedErrataAPI(object):
                 "id": 89,
                 "short_name": "product",
             },
+            "release": {
+                "id": 652,
+                "name": "RHEL-7.4.0",
+            },
             "people": {"reporter": "botas/dev-jenkins.some.strange.letters.redhat.com@REDHAT.COM"},
         }
 
@@ -137,6 +141,14 @@ class MockedErrataAPI(object):
         self.product_versions = {}
         self.product_versions[3] = {"rhel_release": {"name": "RHEL-6-foobar"}}
         self.product_versions[4] = {"rhel_release": {"name": "RHEL-7-foobar"}}
+
+        self.release_rest_json = {
+            "data": {
+                "id": 652,
+                "type": "releases",
+                "attributes": {"name": "RHEL-7.4.0", "description": "RHEL-7.4.0"},
+            }
+        }
 
         self.builds_by_cve = {
             "CVE-2020-12345": {
@@ -262,6 +274,8 @@ class MockedErrataAPI(object):
             return self.builds_list_with_sig_key
         elif endpoint.find("erratum/") != -1:
             return self.advisory_rest_json
+        elif endpoint.find("releases/") != -1:
+            return self.release_rest_json
 
     def errata_http_get(self, endpoint):
         if endpoint.endswith("builds.json"):


### PR DESCRIPTION
This introduces the release_name attribute to the ErrataAdvisory class, it enables filtering events by advisory release name.

JIRA: CWFHEALTH-3043