### PR TITLE
Replace outdated base images with the latest ones

### DIFF
--- a/freshmaker/config.py
+++ b/freshmaker/config.py
@@ -371,6 +371,12 @@ class Config(object):
             'the keys "groups" and "users" which have values that are lists. Any roles not '
             "provided as keys, will contain defaut empty values.",
         },
+        "update_base_image": {
+            "type": bool,
+            "default": False,
+            "desc": "When True, replace base images that are not the latest and are used as "
+            "dependency, the latest published image with the same name and version will be used.",
+        },
         "rebuilt_nvr_release_suffix": {
             "type": str,
             "default": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ moksha-common==1.2.5
     # via moksha-hub
 moksha-hub==1.5.17
     # via -r requirements.in
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl


### PR DESCRIPTION
When a base image included in the rebuild list as a dependency is not the latest published release, replace it with the latest one. This ensures that outdated base images, which might reference non-existent resources, do not cause build failures. By using the latest base images, we can ensure successful image builds.

JIRA: CWFHEALTH-3258