### PR TITLE
Ignore images with missing brew nvr data

### DIFF
--- a/freshmaker/image.py
+++ b/freshmaker/image.py
@@ -726,6 +726,10 @@ class PyxisAPI(object):
         if not images:
             return []
 
+        # Skip images without Brew metadata. Images built and released by Konflux
+        # lack Brew metadata. We don't support rebuilding such images.
+        images = [x for x in images if x["brew"]]
+
         # Avoid manipulating the images directly, use a copy instead
         image_dicts = copy.deepcopy(images)
         del images


### PR DESCRIPTION
Images built and released by Konflux lack Brew metadata. Freshmaker will encounter problems, because it currently expects this data.

This commit makes Freshmaker ignore those images. This is done in `images.PyxisAPI.find_images_with_included_rpms`, right after querying pyxis, by checking the brew nvr field.