### PR TITLE
Update product page query params

### DIFF
--- a/freshmaker/utils.py
+++ b/freshmaker/utils.py
@@ -232,7 +232,7 @@ def get_ocp_release_date(ocp_version):
     url = f"{conf.product_pages_api_url.rstrip('/')}/releases/{ocp_release}/schedule-tasks/"
     resp = requests.get(
         url,
-        params={"name": "GA", "fields": "name,date_finish"},
+        params={"flags_or__in": "ga,ga-main", "fields": "name,date_finish"},
         timeout=conf.net_timeout,
     )
 


### PR DESCRIPTION
Freshmaker queries product page to determine whether an openshift version is released or not, however the old query params doesn't work now because the task name of "GA" is not always used consistently, using the "ga" or "ga-main" flag works for us.