### PR TITLE
Update ubuntu runner image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       RPM_PY_SYS: true
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RPM_PY_SYS: true
     steps:


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.