### PR TITLE
Update GitHub runner image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RPM_PY_SYS: true
     steps:


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be unsupported by April 1.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/