### PR TITLE
CWFHEALTH-5089: Fix IndexError in _get_impacted_bundles when bundle has no brew image

### DIFF
--- a/freshmaker/handlers/botas/botas_shipped_advisory.py
+++ b/freshmaker/handlers/botas/botas_shipped_advisory.py
@@ -365,10 +365,12 @@ class HandleBotasAdvisory(ContainerBuildHandler):
             for bundle in bundles:
                 bundle_images = self._pyxis.get_images_by_digest(bundle["bundle_path_digest"])
                 if not bundle_images:
-                    log.error(
-                        "Image not found with bundle path digest: %s, ignore it.",
+                    log.info(
+                        "No brew image found for bundle path digest: %s, "
+                        "skipping (likely a Konflux-built bundle).",
                         bundle["bundle_path_digest"],
                     )
+                    continue
                 bundle_nvr = bundle_images[0]["brew"]["build"]
                 log.debug("Found impacted bundle: %s", bundle_nvr)
                 impacted_bundles.add(bundle_nvr)

--- a/freshmaker/pyxis.py
+++ b/freshmaker/pyxis.py
@@ -288,9 +288,10 @@ class Pyxis(object):
         :rtype: list
         """
         q_filter = (
-            f"repositories.manifest_list_digest=={digest}"
+            f"(repositories.manifest_list_digest=={digest}"
             + " or "
-            + f"repositories.manifest_schema2_digest=={digest}"
+            + f"repositories.manifest_schema2_digest=={digest})"
+            + " and brew != null"
         )
         request_params = {"include": "data.brew,data.repositories", "filter": q_filter}
         return self._pagination("images", request_params)


### PR DESCRIPTION
get_images_by_digest can return an empty list when a bundle path
digest has no brew-built data in pyxis (e.g. Konflux-built bundles).
    
We need to skip these instead of crashing with an IndexError on bundle_images[0].
We cannot rebuilt operator bundles which were not built in brew.
```    
    Traceback:
      File "freshmaker/handlers/botas/botas_shipped_advisory.py", line 372,
        in _get_impacted_bundles
        bundle_nvr = bundle_images[0]["brew"]["build"]
    IndexError: list index out of range
```    

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>