### PR TITLE
CWFHEALTH-5089: Bump graphql-core and gql

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ Flask
 Flask-Login
 Flask-Migrate
 Flask-SQLAlchemy
-gql[requests, aiohttp]
+gql[requests]
 httplib2
 jira
 jsonformatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 aiohttp==3.9.1
-    # via
-    #   -r requirements.in
-    #   gql
+    # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
 alembic==1.13.0
     # via
     #   -r requirements.in
     #   flask-migrate
+anyio==4.14.2
+    # via gql
 arrow==1.3.0
     # via fedmsg
 attrs==23.1.0
@@ -79,9 +79,9 @@ frozenlist==1.4.0
     #   aiosignal
 future==1.0.0
     # via stomper
-gql[aiohttp,requests]==3.5.0b8
+gql[requests]==4.0.0
     # via -r requirements.in
-graphql-core==3.3.0a3
+graphql-core==3.2.11
     # via gql
 greenlet==3.0.2
     # via sqlalchemy
@@ -95,6 +95,7 @@ hyperlink==21.0.0
     # via twisted
 idna==3.6
     # via
+    #   anyio
     #   hyperlink
     #   requests
     #   twisted
@@ -281,6 +282,7 @@ types-python-dateutil==2.8.19.14
 typing-extensions==4.9.0
     # via
     #   alembic
+    #   anyio
     #   jira
     #   twisted
 urllib3==2.1.0


### PR DESCRIPTION
It is needed for new version of pyxis which is already deployed in production
```
(venv) sh$ python -V
Python 3.12.13

(venv) sh$ pip-compile -P 'graphql-core>=3.2.11' -P 'gql>=4.0' requirements.in --output-file requirements.txt
```
Fixes: CWFHEALTH-5089

@FernandesMF @ElenaKarolinaSemanova PTAL