### PR TITLE
Revert "actions: temporarily switch to new image"

### DIFF
--- a/.github/actions/tests/Dockerfile
+++ b/.github/actions/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/factory2/freshmaker:fc43
+FROM quay.io/factory2/freshmaker:latest
 
 LABEL \
     name="Freshmaker's tests on github actions" \


### PR DESCRIPTION
quay.io/factory2/freshmaker:latest has already necessary dependencies to work with git main

This reverts commit 8974695ddc43cf7e8388fa45a4da4b798ba2761b.