### PR TITLE
CWFHEALTH-5125: Use GSSAPI authenticated bind for LDAP queries

### DIFF
--- a/freshmaker/auth.py
+++ b/freshmaker/auth.py
@@ -133,6 +133,7 @@ def query_ldap_groups(uid):
     :rtype: set
     """
     client = ldap.initialize(conf.auth_ldap_server)
+    client.sasl_gssapi_bind_s()
     users = client.search_s(
         conf.auth_ldap_user_base,
         ldap.SCOPE_ONELEVEL,

--- a/freshmaker/auth.py
+++ b/freshmaker/auth.py
@@ -25,6 +25,7 @@
 from functools import wraps
 import requests
 import ldap
+import ldap.filter
 import flask
 
 from flask import g
@@ -139,7 +140,7 @@ def query_ldap_groups(uid):
             conf.auth_ldap_user_base,
             ldap.SCOPE_ONELEVEL,
             attrlist=["memberOf"],
-            filterstr=f"(&(uid={uid})(objectClass=posixAccount))",
+            filterstr=ldap.filter.filter_format("(&(uid=%s)(objectClass=posixAccount))", [uid]),
         )
 
         group_distinguished_names = set()

--- a/freshmaker/auth.py
+++ b/freshmaker/auth.py
@@ -133,26 +133,29 @@ def query_ldap_groups(uid):
     :rtype: set
     """
     client = ldap.initialize(conf.auth_ldap_server)
-    client.sasl_gssapi_bind_s()
-    users = client.search_s(
-        conf.auth_ldap_user_base,
-        ldap.SCOPE_ONELEVEL,
-        attrlist=["memberOf"],
-        filterstr=f"(&(uid={uid})(objectClass=posixAccount))",
-    )
+    try:
+        client.sasl_gssapi_bind_s()
+        users = client.search_s(
+            conf.auth_ldap_user_base,
+            ldap.SCOPE_ONELEVEL,
+            attrlist=["memberOf"],
+            filterstr=f"(&(uid={uid})(objectClass=posixAccount))",
+        )
 
-    group_distinguished_names = set()
-    if users:
-        # users will only contain one entry if the user exists in the LDAP directory
-        # since the LDAP filter is limited to a single user.
-        _, user_attributes = users[0]
-        group_distinguished_names = {
-            # The value of group is the entire distinguished name of the group
-            group.decode("utf-8")
-            for group in user_attributes.get("memberOf", [])
-        }
+        group_distinguished_names = set()
+        if users:
+            # users will only contain one entry if the user exists in the LDAP directory
+            # since the LDAP filter is limited to a single user.
+            _, user_attributes = users[0]
+            group_distinguished_names = {
+                # The value of group is the entire distinguished name of the group
+                group.decode("utf-8")
+                for group in user_attributes.get("memberOf", [])
+            }
 
-    return group_distinguished_names
+        return group_distinguished_names
+    finally:
+        client.unbind_s()
 
 
 @commit_on_success

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -307,10 +307,12 @@ class TestQueryLdapGroups(FreshmakerTestCase):
         self.assertEqual(expected, groups)
         client = initialize.return_value
         client.sasl_gssapi_bind_s.assert_called_once()
+        client.unbind_s.assert_called_once()
         client.assert_has_calls(
             [
                 call.sasl_gssapi_bind_s(),
                 call.search_s(mock.ANY, mock.ANY, attrlist=mock.ANY, filterstr=mock.ANY),
+                call.unbind_s(),
             ]
         )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,8 @@
 
 import flask
 
-from unittest.mock import patch, Mock
+from unittest import mock
+from unittest.mock import call, patch, Mock
 from werkzeug.exceptions import Unauthorized
 
 import freshmaker.auth
@@ -304,6 +305,14 @@ class TestQueryLdapGroups(FreshmakerTestCase):
             "cn=Forrest Gump,ou=groups,dc=example,dc=com",
         }
         self.assertEqual(expected, groups)
+        client = initialize.return_value
+        client.sasl_gssapi_bind_s.assert_called_once()
+        client.assert_has_calls(
+            [
+                call.sasl_gssapi_bind_s(),
+                call.search_s(mock.ANY, mock.ANY, attrlist=mock.ANY, filterstr=mock.ANY),
+            ]
+        )
 
 
 class TestInitAuth(FreshmakerTestCase):

--- a/yum-packages.txt
+++ b/yum-packages.txt
@@ -6,6 +6,7 @@ git-core
 gobject-introspection-devel
 httpd
 httpd-devel
+cyrus-sasl-gssapi
 krb5-devel
 libpq-devel
 openldap-devel


### PR DESCRIPTION
Switch from anonymous LDAP binding to Kerberos (GSSAPI) authenticated
binding, and add the cyrus-sasl-gssapi system dependency required for
the SASL mechanism.

And couple of more tiny changes found by AI agents 

*  Sanitize uid in LDAP filter to prevent LDAP injection
    
    Escape special LDAP filter characters in the uid parameter using
    ldap.filter.escape_filter_chars() before interpolating into the
    search filter string.
    
* Ensure LDAP connection cleanup with explicit unbind_s
    
    Relying on __del__ for LDAP cleanup is not best practice — if an
    exception occurs mid-function, or on non-CPython runtimes (PyPy,
    etc.), cleanup timing isn't guaranteed. Wrap the LDAP search in
    try/finally with client.unbind_s() to ensure the SASL/GSSAPI context
    and connection are properly released.
    
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>